### PR TITLE
[FEAT] 관리자 로그인 및 인증 흐름 정리 #3

### DIFF
--- a/src/components/auth/landing/KakaoLoginButton.tsx
+++ b/src/components/auth/landing/KakaoLoginButton.tsx
@@ -5,7 +5,7 @@ import { IcKakao } from '@/icons';
 
 export const KakaoLoginButton = () => {
   const theme = useTheme();
-  const { isKakaoLoginLoading, handleKakaoLogin } = useTeacherKakaoLogin();
+  const { isKakaoLoginPending, handleKakaoLogin } = useTeacherKakaoLogin();
 
   return (
     <InlineButton
@@ -17,7 +17,7 @@ export const KakaoLoginButton = () => {
       activeBgColor={theme.colors.kakao.active}
       color={theme.colors.text.text1}
       onClick={handleKakaoLogin}
-      disabled={isKakaoLoginLoading}
+      disabled={isKakaoLoginPending}
     />
   );
 };

--- a/src/components/common/Alert.tsx
+++ b/src/components/common/Alert.tsx
@@ -1,0 +1,110 @@
+import type { Theme } from '@emotion/react';
+import styled from '@emotion/styled';
+import { IcError, IcInfo } from '@/icons';
+import { InlineButton } from '@/components/common/InlineButton';
+
+type AlertVariant = 'error' | 'warning' | 'success';
+
+type AlertProps = {
+  title: string;
+  description?: string;
+  variant?: AlertVariant;
+  onRetry?: () => void;
+};
+
+export const Alert = ({ title, description, variant = 'error', onRetry }: AlertProps) => {
+  const alertRole = variant === 'success' ? 'status' : 'alert';
+
+  return (
+    <AlertContainer role={alertRole} aria-live="polite" $variant={variant}>
+      <AlertContentContainer>
+        <AlertIconContainer $variant={variant}>
+          {variant === 'success' ? (
+            <IcInfo width={18} height={18} />
+          ) : (
+            <IcError width={18} height={18} />
+          )}
+        </AlertIconContainer>
+
+        <AlertTextContainer>
+          <AlertTitle $variant={variant}>{title}</AlertTitle>
+          {description && <AlertDescription $variant={variant}>{description}</AlertDescription>}
+        </AlertTextContainer>
+      </AlertContentContainer>
+
+      {onRetry && <InlineButton variant="ghost" size="L" label="다시 시도" onClick={onRetry} />}
+    </AlertContainer>
+  );
+};
+
+const getAlertVariantStyle = (theme: Theme, variant: AlertVariant) => {
+  if (variant === 'error') {
+    return {
+      backgroundColor: theme.colors.semantic.errorSoft,
+      borderColor: theme.colors.semantic.error,
+      contentColor: theme.colors.semantic.error,
+    };
+  }
+
+  if (variant === 'warning') {
+    return {
+      backgroundColor: theme.colors.semantic.warningSoft,
+      borderColor: theme.colors.semantic.warning,
+      contentColor: theme.colors.semantic.warning,
+    };
+  }
+
+  return {
+    backgroundColor: theme.colors.semantic.successSoft,
+    borderColor: theme.colors.semantic.success,
+    contentColor: theme.colors.semantic.success,
+  };
+};
+
+const AlertContainer = styled.div<{ $variant: AlertVariant }>`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border: 1px solid ${({ theme, $variant }) => getAlertVariantStyle(theme, $variant).borderColor};
+  border-radius: 16px;
+  background: ${({ theme, $variant }) => getAlertVariantStyle(theme, $variant).backgroundColor};
+  padding: 12px 16px;
+  gap: 16px;
+`;
+
+const AlertContentContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  flex: 1;
+`;
+
+const AlertIconContainer = styled.div<{ $variant: AlertVariant }>`
+  display: inline-flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme, $variant }) => getAlertVariantStyle(theme, $variant).contentColor};
+`;
+
+const AlertTextContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+`;
+
+const AlertTitle = styled.p<{ $variant: AlertVariant }>`
+  ${({ theme }) => theme.fonts.labelXS};
+  color: ${({ theme, $variant }) => getAlertVariantStyle(theme, $variant).contentColor};
+  overflow-wrap: break-word;
+  word-break: keep-all;
+`;
+
+const AlertDescription = styled.p<{ $variant: AlertVariant }>`
+  ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme, $variant }) => getAlertVariantStyle(theme, $variant).contentColor};
+  overflow-wrap: break-word;
+  word-break: keep-all;
+`;

--- a/src/components/common/DialogHeader.tsx
+++ b/src/components/common/DialogHeader.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
-import { IconBadge, type IconComponent } from '@/components/common/IconBadge';
+import { IconBadge } from '@/components/common/IconBadge';
+import type { IconComponent } from '@/types/icon';
 
 type DialogHeaderProps = {
   icon: IconComponent;

--- a/src/components/common/FooterCopyright.tsx
+++ b/src/components/common/FooterCopyright.tsx
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const FooterCopyright = () => {
+  return <CopyrightText>© 2026, 소프티 All rights reserved.</CopyrightText>;
+};
+
+const CopyrightText = styled.p`
+  ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme }) => theme.colors.text.text4};
+  text-align: center;
+`;

--- a/src/components/common/IconBadge.tsx
+++ b/src/components/common/IconBadge.tsx
@@ -1,7 +1,5 @@
 import styled from '@emotion/styled';
-import type { ComponentType, SVGProps } from 'react';
-
-export type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+import type { IconComponent } from '@/types/icon';
 
 type IconBadgeProps = {
   icon: IconComponent;

--- a/src/components/common/IconButton.tsx
+++ b/src/components/common/IconButton.tsx
@@ -1,0 +1,72 @@
+import { useTheme } from '@emotion/react';
+import styled from '@emotion/styled';
+import type { ButtonHTMLAttributes } from 'react';
+import type { IconComponent } from '@/types/icon';
+
+type IconButtonVariant = 'primary' | 'ghost' | 'plain';
+
+type IconButtonProps = {
+  icon: IconComponent;
+  variant: IconButtonVariant;
+  accessibilityLabel?: string;
+} & ButtonHTMLAttributes<HTMLButtonElement>;
+
+export const IconButton = ({
+  icon: Icon,
+  variant,
+  disabled = false,
+  accessibilityLabel,
+  ...buttonProps
+}: IconButtonProps) => {
+  const theme = useTheme();
+
+  const iconColor = disabled
+    ? theme.colors.text.text4
+    : variant === 'primary'
+      ? theme.colors.text.textW
+      : theme.colors.text.text1;
+
+  return (
+    <ButtonContainer
+      type="button"
+      $variant={variant}
+      disabled={disabled}
+      aria-label={accessibilityLabel}
+      {...buttonProps}
+    >
+      <Icon color={iconColor} />
+    </ButtonContainer>
+  );
+};
+
+const ButtonContainer = styled.button<{ $variant: IconButtonVariant }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  width: 40px;
+  height: 40px;
+  background-color: ${({ theme, $variant }) =>
+    $variant === 'primary'
+      ? theme.colors.brand.primary
+      : $variant === 'ghost'
+        ? theme.colors.background.bg1
+        : 'transparent'};
+  border-radius: 999px;
+  border: ${({ theme, $variant }) =>
+    $variant === 'ghost' ? `1px solid ${theme.colors.border.border1}` : 'none'};
+  transition:
+    background-color 0.2s ease,
+    opacity 0.2s ease;
+
+  &:hover:not(:disabled),
+  &:active:not(:disabled) {
+    background-color: ${({ theme, $variant }) =>
+      $variant === 'primary' ? theme.colors.brand.primary : theme.colors.background.bg5};
+    opacity: ${({ $variant }) => ($variant === 'primary' ? 0.85 : 1)};
+  }
+
+  &:disabled {
+    background-color: ${({ theme }) => theme.colors.background.bg1};
+  }
+`;

--- a/src/components/common/InlineButton.tsx
+++ b/src/components/common/InlineButton.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
-import type { IconComponent } from '@/components/common/IconBadge';
 import { useTheme } from '@emotion/react';
+import type { IconComponent } from '@/types/icon';
 
 type ButtonSize = 'M' | 'L';
 type ButtonVariants = 'primary' | 'ghost' | 'text';

--- a/src/components/common/InlineButton.tsx
+++ b/src/components/common/InlineButton.tsx
@@ -1,24 +1,24 @@
 import styled from '@emotion/styled';
 import { useTheme } from '@emotion/react';
+import type { ButtonHTMLAttributes } from 'react';
 import type { IconComponent } from '@/types/icon';
 
 type ButtonSize = 'M' | 'L';
 type ButtonVariants = 'primary' | 'ghost' | 'text';
 
-interface InlineButtonProps {
+type InlineButtonProps = {
   variant: ButtonVariants;
   size: ButtonSize;
   icon?: IconComponent;
-  width?: string; // 버튼 너비 지정
-  label: string; // 버튼 라벨 텍스트
+  width?: string;
+  label: string;
   bgColor?: string;
   activeBgColor?: string;
   color?: string;
-  disabled?: boolean;
-  onClick?: () => void;
-}
+} & Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'children' | 'color'>;
 
 export const InlineButton = ({
+  type = 'button',
   variant,
   size,
   icon: Icon,
@@ -27,8 +27,8 @@ export const InlineButton = ({
   bgColor,
   activeBgColor,
   color,
-  disabled,
-  onClick,
+  disabled = false,
+  ...buttonProps
 }: InlineButtonProps) => {
   const theme = useTheme();
 
@@ -42,13 +42,14 @@ export const InlineButton = ({
 
   return (
     <ButtonContainer
+      type={type}
       $variant={variant}
       $size={size}
       $width={width}
       $bgColor={bgColor}
       $activeBgColor={activeBgColor}
-      onClick={onClick}
       disabled={disabled}
+      {...buttonProps}
     >
       {Icon && <Icon color={contentColor} />}
       <ButtonLabel $color={contentColor}>{label}</ButtonLabel>

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -1,0 +1,81 @@
+import styled from '@emotion/styled';
+import type { InputHTMLAttributes } from 'react';
+
+type TextFieldProps = {
+  label?: string;
+  isRequired?: boolean;
+  helperText?: string;
+  errorMessage?: string;
+} & InputHTMLAttributes<HTMLInputElement>;
+
+export const TextField = ({
+  label,
+  isRequired = false,
+  helperText,
+  errorMessage,
+  ...inputProps
+}: TextFieldProps) => {
+  const hasError = Boolean(errorMessage);
+  const helperMessage = errorMessage ?? helperText;
+
+  return (
+    <FieldContainer>
+      {label && (
+        <FieldLabelContainer>
+          <FieldLabelText $hasError={hasError}>{label}</FieldLabelText>
+          {isRequired && <FieldRequiredMark>*</FieldRequiredMark>}
+        </FieldLabelContainer>
+      )}
+
+      <FieldInput $hasError={hasError} {...inputProps} />
+
+      {helperMessage && <HelperText $hasError={hasError}>{helperMessage}</HelperText>}
+    </FieldContainer>
+  );
+};
+
+const FieldContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const FieldLabelContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+`;
+
+const FieldLabelText = styled.span<{ $hasError: boolean }>`
+  ${({ theme }) => theme.fonts.labelS};
+  color: ${({ theme, $hasError }) =>
+    $hasError ? theme.colors.semantic.error : theme.colors.text.text1};
+`;
+
+const FieldRequiredMark = styled.span`
+  ${({ theme }) => theme.fonts.labelS};
+  color: ${({ theme }) => theme.colors.semantic.error};
+`;
+
+const FieldInput = styled.input<{ $hasError: boolean }>`
+  height: 40px;
+  ${({ theme }) => theme.fonts.body2};
+  color: ${({ theme }) => theme.colors.text.text1};
+  background-color: ${({ theme }) => theme.colors.background.bg1};
+  border: 1px solid
+    ${({ theme, $hasError }) =>
+      $hasError ? theme.colors.semantic.error : theme.colors.border.border2};
+  border-radius: 8px;
+  box-sizing: border-box;
+  padding: 8px 12px;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.text4};
+  }
+`;
+
+const HelperText = styled.p<{ $hasError: boolean }>`
+  ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme, $hasError }) =>
+    $hasError ? theme.colors.semantic.error : theme.colors.text.text4};
+`;

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -37,6 +37,7 @@ export const TextField = ({
 const FieldContainer = styled.div`
   display: flex;
   flex-direction: column;
+  width: min(calc(100vw - 32px - 80px), 361px);
   gap: 8px;
 `;
 

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -73,6 +73,11 @@ const FieldInput = styled.input<{ $hasError: boolean }>`
   &::placeholder {
     color: ${({ theme }) => theme.colors.text.text4};
   }
+
+  &:focus {
+    outline: 1px solid ${({ theme }) => theme.colors.brand.primary};
+    border-color: ${({ theme }) => theme.colors.brand.primary};
+  }
 `;
 
 const HelperText = styled.p<{ $hasError: boolean }>`

--- a/src/constants/navigation.ts
+++ b/src/constants/navigation.ts
@@ -1,5 +1,5 @@
 import type { AuthRole } from '@/stores/authStore';
-import type { IconComponent } from '@/components/common/IconBadge.tsx';
+import type { IconComponent } from '@/types/icon';
 import { ROUTES } from '@/constants/routes';
 import { IcInbox, IcReport, IcSettings, IcDashboard, IcErrorReview, IcModel } from '@/icons';
 

--- a/src/constants/storageKeys.ts
+++ b/src/constants/storageKeys.ts
@@ -1,4 +1,5 @@
 export const STORAGE_KEYS = {
   accessToken: 'softy-fe-access-token',
   refreshToken: 'softy-fe-refresh-token',
+  authStatus: 'softy-fe-auth-status',
 } as const;

--- a/src/features/auth/hooks/useAdminLoginForm.ts
+++ b/src/features/auth/hooks/useAdminLoginForm.ts
@@ -6,8 +6,8 @@ import {
   getAuthErrorMessage,
   type AuthErrorMessage,
 } from '@/features/auth/lib/getAuthErrorMessage';
+import { InvalidAuthenticatedUserResponseError } from '@/services/auth/authApi';
 import { adminAuthApi, authApi, authSession } from '@/services/auth';
-import { useToastStore } from '@/stores/toastStore';
 import { ROUTES } from '@/constants/routes';
 
 type LoginErrorState = AuthErrorMessage | null;
@@ -17,12 +17,46 @@ const DEFAULT_LOGIN_ERROR: AuthErrorMessage = {
   description: '입력한 정보를 다시 확인해 주세요.',
 };
 
+const RETRYABLE_STATUS_CODES = [500, 502, 503, 504] as const;
+
+const delay = (ms: number) =>
+  new Promise<void>(resolve => {
+    window.setTimeout(resolve, ms);
+  });
+
+const isRetryableError = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return false;
+  }
+
+  if (!error.response) {
+    return true;
+  }
+
+  const status = error.response.status;
+
+  return RETRYABLE_STATUS_CODES.includes(status as (typeof RETRYABLE_STATUS_CODES)[number]);
+};
+
+const getMeWithRetry = async (accessToken: string) => {
+  try {
+    return await authApi.getMe(accessToken);
+  } catch (error) {
+    if (!isRetryableError(error)) {
+      throw error;
+    }
+
+    await delay(300);
+
+    return authApi.getMe(accessToken);
+  }
+};
+
 type FormSubmitHandler = NonNullable<ComponentProps<'form'>['onSubmit']>;
 
 export const useAdminLoginForm = () => {
   const navigate = useNavigate();
   const { setSignedIn, setSignedOut } = useAuth();
-  const showToast = useToastStore(state => state.showToast);
 
   const [loginId, setLoginId] = useState('');
   const [password, setPassword] = useState('');
@@ -32,6 +66,11 @@ export const useAdminLoginForm = () => {
   const isLoginEnabled = useMemo(() => {
     return !isSubmitting && loginId.trim().length > 0 && password.trim().length > 0;
   }, [isSubmitting, loginId, password]);
+
+  const resetFailedLoginAttempt = () => {
+    authSession.clearSession();
+    setSignedOut();
+  };
 
   const handleChangeLoginId = (value: string) => {
     setLoginId(value);
@@ -65,42 +104,37 @@ export const useAdminLoginForm = () => {
         password: password.trim(),
       });
 
-      if (!response.success || !response.data?.accessToken || !response.data?.refreshToken) {
-        authSession.clearSession();
-        setSignedOut();
+      const accessToken = response.data?.accessToken;
+      const refreshToken = response.data?.refreshToken;
 
-        const nextErrorState: AuthErrorMessage = {
+      if (!response.success || !accessToken || !refreshToken) {
+        resetFailedLoginAttempt();
+
+        setLoginError({
           title: response.message || DEFAULT_LOGIN_ERROR.title,
           description: DEFAULT_LOGIN_ERROR.description,
-        };
+        });
+        return;
+      }
 
-        setLoginError(nextErrorState);
-        showToast(nextErrorState.title, 'error');
+      const me = await getMeWithRetry(accessToken);
+
+      if (me.role !== 'admin') {
+        resetFailedLoginAttempt();
+
+        setLoginError({
+          title: '관리자 계정만 로그인할 수 있어요',
+          description: '교사 계정은 카카오 로그인을 이용해 주세요.',
+        });
         return;
       }
 
       authSession.setTokens({
-        accessToken: response.data.accessToken,
-        refreshToken: response.data.refreshToken,
+        accessToken,
+        refreshToken,
       });
-
-      const me = await authApi.getMe();
-
-      if (me.role !== 'admin') {
-        authSession.clearSession();
-        setSignedOut();
-
-        const nextErrorState: AuthErrorMessage = {
-          title: '관리자 계정만 로그인할 수 있어요',
-          description: '교사 계정은 카카오 로그인을 이용해 주세요.',
-        };
-
-        setLoginError(nextErrorState);
-        showToast(nextErrorState.title, 'error');
-        return;
-      }
-
       authSession.setAuthStatus('SIGNED_IN');
+
       setSignedIn({
         role: me.role,
         user: me.user,
@@ -108,16 +142,22 @@ export const useAdminLoginForm = () => {
 
       navigate(ROUTES.adminDashboard, { replace: true });
     } catch (error) {
-      authSession.clearSession();
-      setSignedOut();
+      resetFailedLoginAttempt();
 
-      const isUnauthorized = error instanceof AxiosError && error.response?.status === 401;
+      if (error instanceof AxiosError && error.response?.status === 401) {
+        setLoginError(DEFAULT_LOGIN_ERROR);
+        return;
+      }
 
-      const nextErrorState = isUnauthorized
-        ? DEFAULT_LOGIN_ERROR
-        : getAuthErrorMessage(error, DEFAULT_LOGIN_ERROR);
+      if (error instanceof InvalidAuthenticatedUserResponseError) {
+        setLoginError({
+          title: '관리자 정보를 확인할 수 없어요',
+          description: '잠시 후 다시 시도해 주세요.',
+        });
+        return;
+      }
 
-      setLoginError(nextErrorState);
+      setLoginError(getAuthErrorMessage(error, DEFAULT_LOGIN_ERROR));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/features/auth/hooks/useAdminLoginForm.ts
+++ b/src/features/auth/hooks/useAdminLoginForm.ts
@@ -1,17 +1,18 @@
+import { AxiosError } from 'axios';
 import { useMemo, useState, type ComponentProps } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { getAuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
+import {
+  getAuthErrorMessage,
+  type AuthErrorMessage,
+} from '@/features/auth/lib/getAuthErrorMessage';
 import { adminAuthApi, authApi, authSession } from '@/services/auth';
 import { useToastStore } from '@/stores/toastStore';
 import { ROUTES } from '@/constants/routes';
 
-type LoginErrorState = {
-  title: string;
-  description: string;
-} | null;
+type LoginErrorState = AuthErrorMessage | null;
 
-const DEFAULT_LOGIN_ERROR: LoginErrorState = {
+const DEFAULT_LOGIN_ERROR: AuthErrorMessage = {
   title: '아이디 또는 비밀번호가 올바르지 않아요',
   description: '입력한 정보를 다시 확인해 주세요.',
 };
@@ -68,13 +69,13 @@ export const useAdminLoginForm = () => {
         authSession.clearSession();
         setSignedOut();
 
-        const message = response.message || DEFAULT_LOGIN_ERROR.title;
-
-        setLoginError({
-          title: message,
+        const nextErrorState: AuthErrorMessage = {
+          title: response.message || DEFAULT_LOGIN_ERROR.title,
           description: DEFAULT_LOGIN_ERROR.description,
-        });
-        showToast(message, 'error');
+        };
+
+        setLoginError(nextErrorState);
+        showToast(nextErrorState.title, 'error');
         return;
       }
 
@@ -89,13 +90,13 @@ export const useAdminLoginForm = () => {
         authSession.clearSession();
         setSignedOut();
 
-        const message = '관리자 계정만 로그인할 수 있어요.';
+        const nextErrorState: AuthErrorMessage = {
+          title: '관리자 계정만 로그인할 수 있어요',
+          description: '교사 계정은 카카오 로그인을 이용해 주세요.',
+        };
 
-        setLoginError({
-          title: message,
-          description: DEFAULT_LOGIN_ERROR.description,
-        });
-        showToast(message, 'error');
+        setLoginError(nextErrorState);
+        showToast(nextErrorState.title, 'error');
         return;
       }
 
@@ -107,16 +108,16 @@ export const useAdminLoginForm = () => {
 
       navigate(ROUTES.adminDashboard, { replace: true });
     } catch (error) {
-      const message = getAuthErrorMessage(error, DEFAULT_LOGIN_ERROR.title);
-
       authSession.clearSession();
       setSignedOut();
 
-      setLoginError({
-        title: message,
-        description: DEFAULT_LOGIN_ERROR.description,
-      });
-      showToast(message, 'error');
+      const isUnauthorized = error instanceof AxiosError && error.response?.status === 401;
+
+      const nextErrorState = isUnauthorized
+        ? DEFAULT_LOGIN_ERROR
+        : getAuthErrorMessage(error, DEFAULT_LOGIN_ERROR);
+
+      setLoginError(nextErrorState);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/features/auth/hooks/useInitializeAuth.ts
+++ b/src/features/auth/hooks/useInitializeAuth.ts
@@ -1,20 +1,61 @@
 import { AxiosError } from 'axios';
 import { useEffect } from 'react';
+import { InvalidAuthenticatedUserResponseError } from '@/services/auth/authApi';
 import { authApi, authSession } from '@/services/auth';
 import { useAuthStore } from '@/stores/authStore';
 
-const shouldClearSession = (error: unknown) => {
-  if (error instanceof AxiosError) {
-    const status = error.response?.status;
+const RETRYABLE_STATUS_CODES = [500, 502, 503, 504] as const;
+const AUTH_INITIALIZATION_RETRY_DELAYS = [300, 700, 1200] as const;
 
-    return status === 401;
+const delay = (ms: number) =>
+  new Promise<void>(resolve => {
+    window.setTimeout(resolve, ms);
+  });
+
+const isUnauthorizedError = (error: unknown) => {
+  return error instanceof AxiosError && error.response?.status === 401;
+};
+
+const isRetryableError = (error: unknown) => {
+  if (!(error instanceof AxiosError)) {
+    return false;
   }
 
-  if (error instanceof Error) {
-    return error.message === '유효하지 않은 사용자 정보 응답입니다.';
+  if (!error.response) {
+    return true;
   }
 
-  return false;
+  const status = error.response.status;
+
+  return RETRYABLE_STATUS_CODES.includes(status as (typeof RETRYABLE_STATUS_CODES)[number]);
+};
+
+const isInvalidAuthenticatedUserResponseError = (error: unknown) => {
+  return error instanceof InvalidAuthenticatedUserResponseError;
+};
+
+const getMeWithRetry = async () => {
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= AUTH_INITIALIZATION_RETRY_DELAYS.length; attempt += 1) {
+    try {
+      return await authApi.getMe();
+    } catch (error) {
+      lastError = error;
+
+      if (!isRetryableError(error)) {
+        throw error;
+      }
+
+      if (attempt === AUTH_INITIALIZATION_RETRY_DELAYS.length) {
+        break;
+      }
+
+      await delay(AUTH_INITIALIZATION_RETRY_DELAYS[attempt]);
+    }
+  }
+
+  throw lastError;
 };
 
 export const useInitializeAuth = () => {
@@ -49,7 +90,7 @@ export const useInitializeAuth = () => {
       }
 
       try {
-        const me = await authApi.getMe();
+        const me = await getMeWithRetry();
 
         if (!isMounted) {
           return;
@@ -61,12 +102,15 @@ export const useInitializeAuth = () => {
           user: me.user,
         });
       } catch (error) {
-        if (shouldClearSession(error)) {
-          authSession.clearSession();
-        }
+        const shouldInvalidateSession =
+          isUnauthorizedError(error) || isInvalidAuthenticatedUserResponseError(error);
 
-        if (isMounted) {
-          setSignedOut();
+        if (shouldInvalidateSession || isRetryableError(error)) {
+          authSession.clearSession();
+
+          if (isMounted) {
+            setSignedOut();
+          }
         }
 
         if (import.meta.env.DEV) {

--- a/src/features/auth/hooks/useInitializeAuth.ts
+++ b/src/features/auth/hooks/useInitializeAuth.ts
@@ -7,14 +7,11 @@ const shouldClearSession = (error: unknown) => {
   if (error instanceof AxiosError) {
     const status = error.response?.status;
 
-    return status === 401 || status === 403;
+    return status === 401;
   }
 
   if (error instanceof Error) {
-    return (
-      error.message === '유효하지 않은 사용자 정보 응답입니다.' ||
-      error.message === '유효하지 않은 사용자 역할입니다.'
-    );
+    return error.message === '유효하지 않은 사용자 정보 응답입니다.';
   }
 
   return false;

--- a/src/features/auth/hooks/useTeacherKakaoCallback.ts
+++ b/src/features/auth/hooks/useTeacherKakaoCallback.ts
@@ -46,12 +46,12 @@ export const useTeacherKakaoCallback = () => {
         const kakaoErrorDescription = getKakaoErrorDescriptionFromQuery(location.search);
 
         if (kakaoError) {
-          const toastMessage = getKakaoLoginErrorMessage(
+          const toastError = getKakaoLoginErrorMessage(
             new Error(kakaoErrorDescription || kakaoError)
           );
 
-          if (toastMessage) {
-            showToast(toastMessage, 'error');
+          if (toastError) {
+            showToast(toastError.title, 'error');
           }
 
           navigate(ROUTES.root, { replace: true });
@@ -62,10 +62,10 @@ export const useTeacherKakaoCallback = () => {
         const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI as string | undefined;
 
         if (!code || !redirectUri) {
-          const toastMessage = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
+          const toastError = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
 
-          if (toastMessage) {
-            showToast(toastMessage, 'error');
+          if (toastError) {
+            showToast(toastError.title, 'error');
           }
 
           navigate(ROUTES.root, { replace: true });
@@ -78,12 +78,12 @@ export const useTeacherKakaoCallback = () => {
         });
 
         if (!response.success || !response.data?.accessToken || !response.data?.refreshToken) {
-          const toastMessage = getKakaoLoginErrorMessage(
+          const toastError = getKakaoLoginErrorMessage(
             new Error(response.message || KAKAO_LOGIN_ERROR_MESSAGE)
           );
 
-          if (toastMessage) {
-            showToast(toastMessage, 'error');
+          if (toastError) {
+            showToast(toastError.title, 'error');
           }
 
           authSession.clearSession();
@@ -117,10 +117,10 @@ export const useTeacherKakaoCallback = () => {
         authSession.clearSession();
         setSignedOut();
 
-        const toastMessage = getKakaoLoginErrorMessage(error);
+        const toastError = getKakaoLoginErrorMessage(error);
 
-        if (toastMessage) {
-          showToast(toastMessage, 'error');
+        if (toastError) {
+          showToast(toastError.title, 'error');
         }
 
         if (import.meta.env.DEV) {

--- a/src/features/auth/hooks/useTeacherKakaoCallback.ts
+++ b/src/features/auth/hooks/useTeacherKakaoCallback.ts
@@ -1,30 +1,12 @@
 import { useEffect, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { authApi, authSession, teacherAuthApi } from '@/services/auth';
+import { authSession } from '@/services/auth';
 import { useToastStore } from '@/stores/toastStore';
 import { ROUTES } from '@/constants/routes';
 import { getKakaoLoginErrorMessage } from '@/features/auth/lib/getKakaoLoginErrorMessage';
-
-const KAKAO_LOGIN_ERROR_MESSAGE = '카카오 로그인에 실패했어요. 잠시 후 다시 시도해 주세요.';
-
-const getKakaoCodeFromQuery = (search: string) => {
-  const searchParams = new URLSearchParams(search);
-
-  return searchParams.get('code') || '';
-};
-
-const getKakaoErrorFromQuery = (search: string) => {
-  const searchParams = new URLSearchParams(search);
-
-  return searchParams.get('error') || '';
-};
-
-const getKakaoErrorDescriptionFromQuery = (search: string) => {
-  const searchParams = new URLSearchParams(search);
-
-  return searchParams.get('error_description') || '';
-};
+import { parseKakaoCallbackQuery } from '@/features/auth/lib/parseKakaoCallbackQuery';
+import { processTeacherKakaoCallback } from '@/features/auth/lib/processTeacherKakaoCallback';
 
 export const useTeacherKakaoCallback = () => {
   const navigate = useNavigate();
@@ -42,74 +24,55 @@ export const useTeacherKakaoCallback = () => {
       isHandledRef.current = true;
 
       try {
-        const kakaoError = getKakaoErrorFromQuery(location.search);
-        const kakaoErrorDescription = getKakaoErrorDescriptionFromQuery(location.search);
+        const { code, error, errorDescription } = parseKakaoCallbackQuery(location.search);
 
-        if (kakaoError) {
-          const toastError = getKakaoLoginErrorMessage(
-            new Error(kakaoErrorDescription || kakaoError)
-          );
+        if (error) {
+          const toastMessage = getKakaoLoginErrorMessage(new Error(errorDescription || error));
 
-          if (toastError) {
-            showToast(toastError.title, 'error');
+          if (toastMessage) {
+            showToast(toastMessage, 'error');
           }
 
           navigate(ROUTES.root, { replace: true });
           return;
         }
 
-        const code = getKakaoCodeFromQuery(location.search);
         const redirectUri = import.meta.env.VITE_KAKAO_REDIRECT_URI as string | undefined;
 
-        if (!code || !redirectUri) {
-          const toastError = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
-
-          if (toastError) {
-            showToast(toastError.title, 'error');
-          }
-
-          navigate(ROUTES.root, { replace: true });
-          return;
-        }
-
-        const response = await teacherAuthApi.loginWithKakao({
+        const result = await processTeacherKakaoCallback({
           code,
           redirectUri,
         });
 
-        if (!response.success || !response.data?.accessToken || !response.data?.refreshToken) {
-          const toastError = getKakaoLoginErrorMessage(
-            new Error(response.message || KAKAO_LOGIN_ERROR_MESSAGE)
-          );
-
-          if (toastError) {
-            showToast(toastError.title, 'error');
-          }
-
+        if (result.status === 'error') {
           authSession.clearSession();
           setSignedOut();
+          showToast(result.message, 'error');
           navigate(ROUTES.root, { replace: true });
           return;
         }
 
-        authSession.setTokens({
-          accessToken: response.data.accessToken,
-          refreshToken: response.data.refreshToken,
-        });
-
-        if (response.data.registrationRequired) {
+        if (result.status === 'signup_required') {
+          authSession.setTokens({
+            accessToken: result.accessToken,
+            refreshToken: result.refreshToken,
+          });
           authSession.setAuthStatus('SIGNUP_REQUIRED');
+
           setSignupRequired();
           navigate(ROUTES.teacherSignUp, { replace: true });
           return;
         }
 
-        const me = await authApi.getMe();
-
+        authSession.setTokens({
+          accessToken: result.accessToken,
+          refreshToken: result.refreshToken,
+        });
         authSession.setAuthStatus('SIGNED_IN');
+
         setSignedIn({
-          role: me.role,
-          user: me.user,
+          role: result.role,
+          user: result.user,
         });
 
         navigate(ROUTES.teacherThreadList, { replace: true });
@@ -117,10 +80,10 @@ export const useTeacherKakaoCallback = () => {
         authSession.clearSession();
         setSignedOut();
 
-        const toastError = getKakaoLoginErrorMessage(error);
+        const toastMessage = getKakaoLoginErrorMessage(error);
 
-        if (toastError) {
-          showToast(toastError.title, 'error');
+        if (toastMessage) {
+          showToast(toastMessage, 'error');
         }
 
         if (import.meta.env.DEV) {

--- a/src/features/auth/hooks/useTeacherKakaoLogin.ts
+++ b/src/features/auth/hooks/useTeacherKakaoLogin.ts
@@ -17,10 +17,10 @@ export const useTeacherKakaoLogin = () => {
     }
 
     if (!kakaoLoginUrl) {
-      const toastMessage = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
+      const toastError = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
 
-      if (toastMessage) {
-        showToast(toastMessage, 'error');
+      if (toastError) {
+        showToast(toastError.title, 'error');
       }
 
       if (import.meta.env.DEV) {

--- a/src/features/auth/hooks/useTeacherKakaoLogin.ts
+++ b/src/features/auth/hooks/useTeacherKakaoLogin.ts
@@ -3,41 +3,43 @@ import { useToastStore } from '@/stores/toastStore';
 import { getKakaoLoginStartUrl } from '@/features/auth/lib/getKakaoLoginStartUrl';
 import { getKakaoLoginErrorMessage } from '@/features/auth/lib/getKakaoLoginErrorMessage';
 
-const KAKAO_LOGIN_ERROR_MESSAGE = '카카오 로그인에 실패했어요. 잠시 후 다시 시도해 주세요.';
+const KAKAO_LOGIN_START_ERROR = new Error(
+  '카카오 로그인에 실패했어요. 잠시 후 다시 시도해 주세요.'
+);
 
 export const useTeacherKakaoLogin = () => {
-  const [isKakaoLoginLoading, setIsKakaoLoginLoading] = useState(false);
+  const [isKakaoLoginPending, setIsKakaoLoginPending] = useState(false);
   const showToast = useToastStore(state => state.showToast);
 
   const kakaoLoginUrl = useMemo(() => getKakaoLoginStartUrl(), []);
+  const canStartKakaoLogin = Boolean(kakaoLoginUrl) && !isKakaoLoginPending;
 
   const handleKakaoLogin = () => {
-    if (isKakaoLoginLoading) {
+    if (!canStartKakaoLogin) {
+      if (!kakaoLoginUrl) {
+        const toastMessage = getKakaoLoginErrorMessage(KAKAO_LOGIN_START_ERROR);
+
+        if (toastMessage) {
+          showToast(toastMessage, 'error');
+        }
+
+        if (import.meta.env.DEV) {
+          console.error(
+            '카카오 로그인 URL 생성 실패: VITE_KAKAO_AUTH_URL 또는 VITE_KAKAO_REST_API_KEY / VITE_KAKAO_REDIRECT_URI를 확인하세요.'
+          );
+        }
+      }
+
       return;
     }
 
-    if (!kakaoLoginUrl) {
-      const toastError = getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE));
-
-      if (toastError) {
-        showToast(toastError.title, 'error');
-      }
-
-      if (import.meta.env.DEV) {
-        console.error(
-          '카카오 로그인 URL 생성 실패: VITE_KAKAO_AUTH_URL 또는 VITE_KAKAO_REST_API_KEY / VITE_KAKAO_REDIRECT_URI를 확인하세요.'
-        );
-      }
-
-      return;
-    }
-
-    setIsKakaoLoginLoading(true);
+    setIsKakaoLoginPending(true);
     window.location.href = kakaoLoginUrl;
   };
 
   return {
-    isKakaoLoginLoading,
+    isKakaoLoginPending,
+    canStartKakaoLogin,
     handleKakaoLogin,
   };
 };

--- a/src/features/auth/hooks/useTeacherSignUpForm.ts
+++ b/src/features/auth/hooks/useTeacherSignUpForm.ts
@@ -1,7 +1,11 @@
+import { AxiosError } from 'axios';
 import { useMemo, useState, type ComponentProps } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
-import { getAuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
+import {
+  getAuthErrorMessage,
+  type AuthErrorMessage,
+} from '@/features/auth/lib/getAuthErrorMessage';
 import { authApi, authSession, teacherAuthApi } from '@/services/auth';
 import { ROUTES } from '@/constants/routes';
 
@@ -12,12 +16,9 @@ type FieldErrors = {
   classNumber?: string;
 };
 
-type GlobalError = {
-  title: string;
-  description: string;
-} | null;
+type GlobalError = AuthErrorMessage | null;
 
-const FORM_ERROR_FALLBACK: GlobalError = {
+const FORM_ERROR_FALLBACK: AuthErrorMessage = {
   title: '회원가입 중 문제가 발생했어요',
   description: '잠시 후 다시 시도해 주세요.',
 };
@@ -116,22 +117,20 @@ export const useTeacherSignUpForm = () => {
 
       navigate(ROUTES.teacherThreadList, { replace: true });
     } catch (error) {
-      const message = getAuthErrorMessage(error, FORM_ERROR_FALLBACK.title);
+      if (error instanceof AxiosError) {
+        const status = error.response?.status;
 
-      if (
-        message === '인증 정보가 유효하지 않아요. 다시 시도해 주세요.' ||
-        message === '접근 권한이 없어요.'
-      ) {
-        authSession.clearSession();
-        setSignedOut();
-        navigate(ROUTES.root, { replace: true });
-        return;
+        if (status === 401 || status === 403) {
+          authSession.clearSession();
+          setSignedOut();
+          navigate(ROUTES.root, { replace: true });
+          return;
+        }
       }
 
-      setGlobalError({
-        title: message,
-        description: FORM_ERROR_FALLBACK.description,
-      });
+      const nextErrorState = getAuthErrorMessage(error, FORM_ERROR_FALLBACK);
+
+      setGlobalError(nextErrorState);
     } finally {
       setIsSubmitting(false);
     }

--- a/src/features/auth/lib/getAuthErrorMessage.ts
+++ b/src/features/auth/lib/getAuthErrorMessage.ts
@@ -5,47 +5,91 @@ type ErrorResponseBody = {
   message?: string;
 };
 
-export const getAuthErrorMessage = (error: unknown, fallbackMessage: string) => {
+export type AuthErrorMessage = {
+  title: string;
+  description?: string;
+};
+
+export const getAuthErrorMessage = (
+  error: unknown,
+  fallbackMessage: AuthErrorMessage
+): AuthErrorMessage => {
   if (error instanceof AxiosError) {
     const axiosError = error as AxiosError<ErrorResponseBody>;
     const status = axiosError.response?.status;
     const code = axiosError.response?.data?.code;
     const message = axiosError.response?.data?.message?.trim();
 
+    if (!axiosError.response) {
+      if (axiosError.code === 'ECONNABORTED') {
+        return {
+          title: '서버 응답이 지연되고 있어요',
+          description: '잠시 후 다시 시도해 주세요.',
+        };
+      }
+
+      return {
+        title: '서버에 연결할 수 없어요',
+        description: '네트워크 상태를 확인하거나 잠시 후 다시 시도해 주세요.',
+      };
+    }
+
     if (message) {
-      return message;
+      return {
+        title: message,
+        description: fallbackMessage.description,
+      };
     }
 
     if (status === 401) {
-      return '인증 정보가 유효하지 않아요. 다시 시도해 주세요.';
+      return {
+        title: '인증 정보가 유효하지 않아요',
+        description: '다시 시도해 주세요.',
+      };
     }
 
     if (status === 403) {
-      return '접근 권한이 없어요.';
+      return {
+        title: '접근 권한이 없어요',
+      };
     }
 
     if (status === 404) {
-      return '요청한 정보를 찾을 수 없어요.';
+      return {
+        title: '요청한 정보를 찾을 수 없어요',
+      };
     }
 
     if (status === 409 || code === 409 || code === 312) {
-      return '이미 처리된 요청이에요.';
+      return {
+        title: '이미 처리된 요청이에요',
+      };
     }
 
     if (code === 313) {
-      return '현재 상태에서는 요청을 처리할 수 없어요.';
+      return {
+        title: '현재 상태에서는 요청을 처리할 수 없어요',
+      };
     }
 
     if (status === 422) {
-      return '입력 정보를 다시 확인해 주세요.';
+      return {
+        title: '입력 정보를 다시 확인해 주세요',
+      };
     }
 
     if (status === 500 || code === 309 || code === 310 || code === 311) {
-      return '서버 처리 중 문제가 발생했어요. 잠시 후 다시 시도해 주세요.';
+      return {
+        title: '서버 처리 중 문제가 발생했어요',
+        description: '잠시 후 다시 시도해 주세요.',
+      };
     }
 
     if (status === 502 || status === 503 || status === 504) {
-      return '서버 연결이 원활하지 않아요. 잠시 후 다시 시도해 주세요.';
+      return {
+        title: '서버 연결이 원활하지 않아요',
+        description: '잠시 후 다시 시도해 주세요.',
+      };
     }
   }
 
@@ -53,7 +97,10 @@ export const getAuthErrorMessage = (error: unknown, fallbackMessage: string) => 
     const message = error.message.trim();
 
     if (message) {
-      return message;
+      return {
+        title: message,
+        description: fallbackMessage.description,
+      };
     }
   }
 

--- a/src/features/auth/lib/getKakaoLoginErrorMessage.ts
+++ b/src/features/auth/lib/getKakaoLoginErrorMessage.ts
@@ -1,15 +1,12 @@
 import { AxiosError } from 'axios';
-import {
-  getAuthErrorMessage,
-  type AuthErrorMessage,
-} from '@/features/auth/lib/getAuthErrorMessage';
+import { getAuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
 
-const KAKAO_LOGIN_ERROR_MESSAGE: AuthErrorMessage = {
+const KAKAO_LOGIN_ERROR_MESSAGE = {
   title: '카카오 로그인에 실패했어요',
   description: '잠시 후 다시 시도해 주세요.',
 };
 
-export const getKakaoLoginErrorMessage = (error: unknown): AuthErrorMessage | null => {
+export const getKakaoLoginErrorMessage = (error: unknown): string | null => {
   if (error instanceof AxiosError) {
     const responseMessage = error.response?.data?.message;
     const errorMessage = error.message.trim();
@@ -23,9 +20,7 @@ export const getKakaoLoginErrorMessage = (error: unknown): AuthErrorMessage | nu
       return null;
     }
 
-    const authErrorMessage = getAuthErrorMessage(error, KAKAO_LOGIN_ERROR_MESSAGE);
-
-    return authErrorMessage;
+    return getAuthErrorMessage(error, KAKAO_LOGIN_ERROR_MESSAGE).title;
   }
 
   if (error instanceof Error) {
@@ -41,21 +36,15 @@ export const getKakaoLoginErrorMessage = (error: unknown): AuthErrorMessage | nu
     }
 
     if (normalizedMessage.includes('network')) {
-      return {
-        title: '서버에 연결할 수 없어요',
-        description: '네트워크 연결을 확인한 뒤 다시 시도해 주세요.',
-      };
+      return '서버에 연결할 수 없어요';
     }
 
     if (message) {
-      return {
-        title: message,
-        description: KAKAO_LOGIN_ERROR_MESSAGE.description,
-      };
+      return message;
     }
 
-    return KAKAO_LOGIN_ERROR_MESSAGE;
+    return KAKAO_LOGIN_ERROR_MESSAGE.title;
   }
 
-  return KAKAO_LOGIN_ERROR_MESSAGE;
+  return KAKAO_LOGIN_ERROR_MESSAGE.title;
 };

--- a/src/features/auth/lib/getKakaoLoginErrorMessage.ts
+++ b/src/features/auth/lib/getKakaoLoginErrorMessage.ts
@@ -1,12 +1,19 @@
 import { AxiosError } from 'axios';
-import { getAuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
+import {
+  getAuthErrorMessage,
+  type AuthErrorMessage,
+} from '@/features/auth/lib/getAuthErrorMessage';
 
-const KAKAO_LOGIN_ERROR_MESSAGE = '카카오 로그인에 실패했어요. 잠시 후 다시 시도해 주세요.';
+const KAKAO_LOGIN_ERROR_MESSAGE: AuthErrorMessage = {
+  title: '카카오 로그인에 실패했어요',
+  description: '잠시 후 다시 시도해 주세요.',
+};
 
-export const getKakaoLoginErrorMessage = (error: unknown): string | null => {
+export const getKakaoLoginErrorMessage = (error: unknown): AuthErrorMessage | null => {
   if (error instanceof AxiosError) {
-    const message = getAuthErrorMessage(error, '');
-    const normalizedMessage = message.toLowerCase();
+    const responseMessage = error.response?.data?.message;
+    const errorMessage = error.message.trim();
+    const normalizedMessage = `${responseMessage ?? ''} ${errorMessage}`.toLowerCase();
 
     if (
       normalizedMessage.includes('cancel') ||
@@ -16,15 +23,9 @@ export const getKakaoLoginErrorMessage = (error: unknown): string | null => {
       return null;
     }
 
-    if (normalizedMessage.includes('network')) {
-      return '네트워크 연결을 확인한 뒤 다시 시도해 주세요.';
-    }
+    const authErrorMessage = getAuthErrorMessage(error, KAKAO_LOGIN_ERROR_MESSAGE);
 
-    if (message) {
-      return message;
-    }
-
-    return KAKAO_LOGIN_ERROR_MESSAGE;
+    return authErrorMessage;
   }
 
   if (error instanceof Error) {
@@ -40,11 +41,17 @@ export const getKakaoLoginErrorMessage = (error: unknown): string | null => {
     }
 
     if (normalizedMessage.includes('network')) {
-      return '네트워크 연결을 확인한 뒤 다시 시도해 주세요.';
+      return {
+        title: '서버에 연결할 수 없어요',
+        description: '네트워크 연결을 확인한 뒤 다시 시도해 주세요.',
+      };
     }
 
     if (message) {
-      return message;
+      return {
+        title: message,
+        description: KAKAO_LOGIN_ERROR_MESSAGE.description,
+      };
     }
 
     return KAKAO_LOGIN_ERROR_MESSAGE;

--- a/src/features/auth/lib/parseKakaoCallbackQuery.ts
+++ b/src/features/auth/lib/parseKakaoCallbackQuery.ts
@@ -1,0 +1,15 @@
+export type KakaoCallbackQuery = {
+  code: string;
+  error: string;
+  errorDescription: string;
+};
+
+export const parseKakaoCallbackQuery = (search: string): KakaoCallbackQuery => {
+  const searchParams = new URLSearchParams(search);
+
+  return {
+    code: searchParams.get('code') || '',
+    error: searchParams.get('error') || '',
+    errorDescription: searchParams.get('error_description') || '',
+  };
+};

--- a/src/features/auth/lib/processTeacherKakaoCallback.ts
+++ b/src/features/auth/lib/processTeacherKakaoCallback.ts
@@ -1,0 +1,80 @@
+import { getKakaoLoginErrorMessage } from '@/features/auth/lib/getKakaoLoginErrorMessage';
+import { authApi, teacherAuthApi } from '@/services/auth';
+
+type ProcessTeacherKakaoCallbackParams = {
+  code: string;
+  redirectUri?: string;
+};
+
+type ProcessTeacherKakaoCallbackResult =
+  | {
+      status: 'error';
+      message: string;
+    }
+  | {
+      status: 'signup_required';
+      accessToken: string;
+      refreshToken: string;
+    }
+  | {
+      status: 'signed_in';
+      accessToken: string;
+      refreshToken: string;
+      role: 'teacher' | 'admin';
+      user: {
+        name: string;
+        grade?: number;
+        classNumber?: number;
+      };
+    };
+
+const KAKAO_LOGIN_ERROR_MESSAGE = '카카오 로그인에 실패했어요. 잠시 후 다시 시도해 주세요.';
+
+export const processTeacherKakaoCallback = async ({
+  code,
+  redirectUri,
+}: ProcessTeacherKakaoCallbackParams): Promise<ProcessTeacherKakaoCallbackResult> => {
+  if (!code || !redirectUri) {
+    return {
+      status: 'error',
+      message:
+        getKakaoLoginErrorMessage(new Error(KAKAO_LOGIN_ERROR_MESSAGE)) ??
+        '카카오 로그인에 실패했어요',
+    };
+  }
+
+  const response = await teacherAuthApi.loginWithKakao({
+    code,
+    redirectUri,
+  });
+
+  const accessToken = response.data?.accessToken;
+  const refreshToken = response.data?.refreshToken;
+
+  if (!response.success || !accessToken || !refreshToken) {
+    return {
+      status: 'error',
+      message:
+        getKakaoLoginErrorMessage(new Error(response.message || KAKAO_LOGIN_ERROR_MESSAGE)) ??
+        '카카오 로그인에 실패했어요',
+    };
+  }
+
+  if (response.data.registrationRequired) {
+    return {
+      status: 'signup_required',
+      accessToken,
+      refreshToken,
+    };
+  }
+
+  const me = await authApi.getMe(accessToken);
+
+  return {
+    status: 'signed_in',
+    accessToken,
+    refreshToken,
+    role: me.role,
+    user: me.user,
+  };
+};

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,24 +1,18 @@
+import { useShallow } from 'zustand/react/shallow';
 import { useAuthStore } from '@/stores/authStore';
 
 export const useAuth = () => {
-  const authStatus = useAuthStore(state => state.authStatus);
-  const role = useAuthStore(state => state.role);
-  const user = useAuthStore(state => state.user);
-  const isAuthInitialized = useAuthStore(state => state.isAuthInitialized);
-  const setSignedOut = useAuthStore(state => state.setSignedOut);
-  const setSignupRequired = useAuthStore(state => state.setSignupRequired);
-  const setSignedIn = useAuthStore(state => state.setSignedIn);
-  const setAuthInitialized = useAuthStore(state => state.setAuthInitialized);
-
-  return {
-    authStatus,
-    role,
-    user,
-    isAuthInitialized,
-    setSignedOut,
-    setSignupRequired,
-    setSignedIn,
-    setAuthInitialized,
-    isAuthenticated: authStatus !== 'SIGNED_OUT',
-  };
+  return useAuthStore(
+    useShallow(state => ({
+      authStatus: state.authStatus,
+      role: state.role,
+      user: state.user,
+      isAuthInitialized: state.isAuthInitialized,
+      setSignedOut: state.setSignedOut,
+      setSignupRequired: state.setSignupRequired,
+      setSignedIn: state.setSignedIn,
+      setAuthInitialized: state.setAuthInitialized,
+      isAuthenticated: state.authStatus !== 'SIGNED_OUT',
+    }))
+  );
 };

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,7 +1,8 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
-import { IconBadge, type IconComponent } from '@/components/common/IconBadge';
+import { IconBadge } from '@/components/common/IconBadge';
 import { InlineButton } from '@/components/common/InlineButton';
+import type { IconComponent } from '@/types/icon';
 import { IcError } from '@/icons';
 
 type ErrorPageProps = {

--- a/src/pages/auth/AdminLoginPage.tsx
+++ b/src/pages/auth/AdminLoginPage.tsx
@@ -1,8 +1,13 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
-import { ROUTES } from '@/constants/routes';
-import { IcBack, IcInfo } from '@/icons';
 import { useAdminLoginForm } from '@/features/auth/hooks/useAdminLoginForm';
+import { Alert } from '@/components/common/Alert';
+import { FooterCopyright } from '@/components/common/FooterCopyright';
+import { IconButton } from '@/components/common/IconButton';
+import { InlineButton } from '@/components/common/InlineButton';
+import { TextField } from '@/components/common/TextField';
+import { IcBack } from '@/icons';
+import { ROUTES } from '@/constants/routes';
 
 export const AdminLoginPage = () => {
   const navigate = useNavigate();
@@ -10,7 +15,6 @@ export const AdminLoginPage = () => {
   const {
     loginId,
     password,
-    isSubmitting,
     loginError,
     isLoginEnabled,
     handleChangeLoginId,
@@ -24,217 +28,113 @@ export const AdminLoginPage = () => {
 
   return (
     <AdminLoginPageContainer>
-      <ContentArea>
-        <BackButton type="button" onClick={handleGoBack} aria-label="뒤로가기">
-          <IcBack />
-        </BackButton>
+      <AdminLoginContent>
+        <IconButton
+          icon={IcBack}
+          variant="plain"
+          onClick={handleGoBack}
+          accessibilityLabel="뒤로가기"
+        />
 
-        <LoginCard>
-          <Title>관리자 로그인</Title>
+        <AdminLoginCard>
+          <AdminLoginForm onSubmit={handleSubmit}>
+            <AdminLoginTitle>관리자 로그인</AdminLoginTitle>
 
-          <LoginForm onSubmit={handleSubmit}>
-            <InputGroup>
-              <Label htmlFor="loginId">아이디</Label>
-              <Input
+            <AdminLoginInputSection>
+              <TextField
                 id="loginId"
                 name="loginId"
                 type="text"
                 autoComplete="username"
+                label="아이디"
                 value={loginId}
                 onChange={event => handleChangeLoginId(event.target.value)}
                 placeholder="아이디를 입력해주세요."
               />
-            </InputGroup>
 
-            <InputGroup>
-              <Label htmlFor="password">비밀번호</Label>
-              <Input
+              <TextField
                 id="password"
                 name="password"
                 type="password"
                 autoComplete="current-password"
+                label="비밀번호"
                 value={password}
                 onChange={event => handleChangePassword(event.target.value)}
                 placeholder="비밀번호를 입력해주세요."
               />
-            </InputGroup>
+            </AdminLoginInputSection>
 
-            {loginError ? (
-              <ErrorBox role="alert" aria-live="polite">
-                <ErrorIconWrap>
-                  <IcInfo />
-                </ErrorIconWrap>
-                <ErrorTextWrap>
-                  <ErrorTitle>{loginError.title}</ErrorTitle>
-                  <ErrorDescription>{loginError.description}</ErrorDescription>
-                </ErrorTextWrap>
-              </ErrorBox>
-            ) : null}
+            <AdminLoginActionSection>
+              {loginError && (
+                <Alert
+                  title={loginError.title}
+                  description={loginError.description}
+                  variant="error"
+                />
+              )}
 
-            <LoginButton type="submit" disabled={!isLoginEnabled}>
-              {isSubmitting ? '로그인 중...' : '로그인'}
-            </LoginButton>
-          </LoginForm>
-        </LoginCard>
-      </ContentArea>
+              <InlineButton
+                type="submit"
+                variant="primary"
+                size="L"
+                label="로그인"
+                disabled={!isLoginEnabled}
+              />
+            </AdminLoginActionSection>
+          </AdminLoginForm>
+        </AdminLoginCard>
+      </AdminLoginContent>
 
-      <FooterText>© 2026, 소프티 All rights reserved.</FooterText>
+      <FooterCopyright />
     </AdminLoginPageContainer>
   );
 };
 
 const AdminLoginPageContainer = styled.div`
-  min-height: 100vh;
-  background: #e5e5e5;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 24px 16px 32px;
+  min-height: 100vh;
+  background: ${({ theme }) => theme.colors.background.bg2};
+  padding: 32px 16px;
+  gap: 80px;
 `;
 
-const ContentArea = styled.div`
-  width: 100%;
-  max-width: 620px;
+const AdminLoginContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
 `;
 
-const BackButton = styled.button`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 36px;
-  height: 36px;
+const AdminLoginCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  border-radius: 16px;
+  padding: 40px;
+`;
+
+const AdminLoginForm = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 36px;
+`;
+
+const AdminLoginTitle = styled.h1`
+  ${({ theme }) => theme.fonts.labelL};
   color: ${({ theme }) => theme.colors.text.text1};
-
-  svg {
-    width: 22px;
-    height: 22px;
-  }
-`;
-
-const LoginCard = styled.div`
-  margin-top: 18px;
-  width: 100%;
-  max-width: 540px;
-  background: #f4f4f4;
-  border-radius: 18px;
-  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.12);
-  padding: 44px 48px 42px;
-
-  @media (max-width: 640px) {
-    padding: 30px 18px 24px;
-  }
-`;
-
-const Title = styled.h1`
-  ${({ theme }) => theme.fonts.title2};
-  color: ${({ theme }) => theme.colors.text.text1};
-  margin: 0;
   text-align: center;
 `;
 
-const LoginForm = styled.form`
-  margin-top: 28px;
+const AdminLoginInputSection = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
 `;
 
-const InputGroup = styled.div`
+const AdminLoginActionSection = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 10px;
-`;
-
-const Label = styled.label`
-  ${({ theme }) => theme.fonts.labelS};
-  color: ${({ theme }) => theme.colors.text.text1};
-`;
-
-const Input = styled.input`
-  ${({ theme }) => theme.fonts.labelS};
-  border: 1px solid #c6c6c6;
-  border-radius: 12px;
-  background: #f4f4f4;
-  padding: 13px 14px;
-  color: ${({ theme }) => theme.colors.text.text1};
-
-  &::placeholder {
-    color: #8d8d8d;
-  }
-
-  &:focus {
-    outline: none;
-    border-color: ${({ theme }) => theme.colors.brand.primary};
-    box-shadow: 0 0 0 2px rgba(85, 181, 166, 0.16);
-  }
-`;
-
-const ErrorBox = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-top: 8px;
-  border-radius: 18px;
-  border: 1px solid #ff5b66;
-  background: #ffe9ec;
-  padding: 14px 16px;
-`;
-
-const ErrorIconWrap = styled.span`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  color: ${({ theme }) => theme.colors.semantic.error};
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
-`;
-
-const ErrorTextWrap = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-`;
-
-const ErrorTitle = styled.p`
-  ${({ theme }) => theme.fonts.labelXS};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
-`;
-
-const ErrorDescription = styled.p`
-  ${({ theme }) => theme.fonts.caption};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
-`;
-
-const LoginButton = styled.button`
-  ${({ theme }) => theme.fonts.labelS};
-  margin-top: 18px;
-  border: none;
-  border-radius: 14px;
-  padding: 14px;
-  color: ${({ theme }) => theme.colors.text.textW};
-  background: ${({ theme }) => theme.colors.brand.primary};
-  transition: background 0.2s ease;
-  cursor: pointer;
-
-  &:hover:not(:disabled) {
-    background: ${({ theme }) => theme.colors.background.brandHover};
-  }
-
-  &:disabled {
-    background: #d0d0d0;
-    color: #747474;
-    cursor: not-allowed;
-  }
-`;
-
-const FooterText = styled.p`
-  ${({ theme }) => theme.fonts.body3};
-  margin: 64px 0 0;
-  color: #919191;
+  gap: 12px;
 `;

--- a/src/pages/auth/LandingPage.tsx
+++ b/src/pages/auth/LandingPage.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/auth/landing';
 import { EXTERNAL_LINKS, landingContent } from '@/constants/landing';
 import { ROUTES } from '@/constants/routes';
+import { FooterCopyright } from '@/components/common/FooterCopyright';
 
 const LANDING_FEATURE_SECTION_ID = 'landing-feature-section';
 
@@ -97,7 +98,9 @@ export const LandingPage = () => {
         onScrollToFeature={handleScrollToFeature}
       />
 
-      <Footer>© 2026, 소프티 All rights reserved.</Footer>
+      <LandingFooter>
+        <FooterCopyright />
+      </LandingFooter>
 
       <ParentAppInstallDialog
         isOpen={isParentAppInstallDialogOpen}
@@ -120,10 +123,7 @@ const HeaderActionContainer = styled.div`
   gap: 10px;
 `;
 
-const Footer = styled.footer`
+const LandingFooter = styled.footer`
   padding: 16px;
-  text-align: center;
   border-top: 1px solid ${({ theme }) => theme.colors.border.border1};
-  ${({ theme }) => theme.fonts.caption};
-  color: ${({ theme }) => theme.colors.text.text4};
 `;

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -7,7 +7,7 @@ export const QueryProvider = ({ children }: PropsWithChildren) => {
       new QueryClient({
         defaultOptions: {
           queries: {
-            retry: 0,
+            retry: 1,
             refetchOnWindowFocus: false,
           },
         },

--- a/src/router/ProtectedRoute.tsx
+++ b/src/router/ProtectedRoute.tsx
@@ -1,5 +1,4 @@
 import { Navigate, Outlet } from 'react-router-dom';
-import { Loader } from '@/components/common/Loader';
 import { useAuth } from '@/hooks/useAuth';
 import type { AuthRole } from '@/stores/authStore';
 import { ROUTES } from '@/constants/routes';
@@ -9,11 +8,7 @@ type ProtectedRouteProps = {
 };
 
 export const ProtectedRoute = ({ allowedRoles }: ProtectedRouteProps) => {
-  const { authStatus, isAuthInitialized, role } = useAuth();
-
-  if (!isAuthInitialized) {
-    return <Loader />;
-  }
+  const { authStatus, role } = useAuth();
 
   if (authStatus === 'SIGNED_OUT') {
     const redirectTo =

--- a/src/router/PublicRoute.tsx
+++ b/src/router/PublicRoute.tsx
@@ -1,16 +1,11 @@
 ﻿import { Navigate, Outlet, useLocation } from 'react-router-dom';
-import { Loader } from '@/components/common/Loader';
 import { useAuth } from '@/hooks/useAuth';
 import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { ROUTES } from '@/constants/routes';
 
 export const PublicRoute = () => {
-  const { authStatus, isAuthInitialized, role } = useAuth();
+  const { authStatus, role } = useAuth();
   const location = useLocation();
-
-  if (!isAuthInitialized) {
-    return <Loader />;
-  }
 
   if (authStatus === 'SIGNUP_REQUIRED') {
     if (location.pathname === ROUTES.teacherSignUp) {

--- a/src/services/auth/adminAuthApi.ts
+++ b/src/services/auth/adminAuthApi.ts
@@ -17,7 +17,7 @@ export type AdminLoginResponse = {
 
 export const adminAuthApi = {
   login: async (payload: AdminLoginRequest) => {
-    const { data } = await apiClient.post<AdminLoginResponse>('/admin/auth/login', payload);
+    const { data } = await apiClient.post<AdminLoginResponse>('/auth/admin/login', payload);
 
     return data;
   },

--- a/src/services/auth/authApi.ts
+++ b/src/services/auth/authApi.ts
@@ -1,7 +1,19 @@
+import type { AxiosRequestConfig } from 'axios';
 import { apiClient } from '@/services/http/apiClient';
 import type { AuthRole } from '@/stores/authStore';
 
 type BackendRole = 'TEACHER' | 'ADMIN';
+
+type AuthRequestConfig = AxiosRequestConfig & {
+  skipUnauthorizedHandling?: boolean;
+};
+
+export class InvalidAuthenticatedUserResponseError extends Error {
+  constructor() {
+    super('유효하지 않은 사용자 인증 응답입니다.');
+    this.name = 'InvalidAuthenticatedUserResponseError';
+  }
+}
 
 export type MeResponse = {
   success: boolean;
@@ -24,16 +36,25 @@ const normalizeRole = (role: BackendRole): Exclude<AuthRole, null> => {
     return 'teacher';
   }
 
-  return 'admin';
+  if (role === 'ADMIN') {
+    return 'admin';
+  }
+
+  throw new InvalidAuthenticatedUserResponseError();
 };
 
 export const authApi = {
-  getMe: async () => {
-    const { data } = await apiClient.get<MeResponse>('/users/me');
+  getMe: async (accessToken?: string) => {
+    const requestConfig: AuthRequestConfig = {
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+      skipUnauthorizedHandling: Boolean(accessToken),
+    };
+
+    const { data } = await apiClient.get<MeResponse>('/users/me', requestConfig);
     const profile = data.data ?? data;
 
-    if (!profile.role || !profile.name) {
-      throw new Error('유효하지 않은 사용자 정보 응답입니다.');
+    if (!profile.role || !profile.name?.trim()) {
+      throw new InvalidAuthenticatedUserResponseError();
     }
 
     return {

--- a/src/services/auth/authApi.ts
+++ b/src/services/auth/authApi.ts
@@ -1,19 +1,30 @@
 import { apiClient } from '@/services/http/apiClient';
+import type { AuthRole } from '@/stores/authStore';
+
+type BackendRole = 'TEACHER' | 'ADMIN';
 
 export type MeResponse = {
   success: boolean;
   code: number;
   message: string;
   data?: {
-    role: 'teacher' | 'admin';
+    role: BackendRole;
     name: string;
     grade: number | null;
     class: number | null;
   };
-  role?: 'teacher' | 'admin';
+  role?: BackendRole;
   name?: string;
   grade?: number | null;
   class?: number | null;
+};
+
+const normalizeRole = (role: BackendRole): Exclude<AuthRole, null> => {
+  if (role === 'TEACHER') {
+    return 'teacher';
+  }
+
+  return 'admin';
 };
 
 export const authApi = {
@@ -25,12 +36,8 @@ export const authApi = {
       throw new Error('유효하지 않은 사용자 정보 응답입니다.');
     }
 
-    if (profile.role !== 'teacher' && profile.role !== 'admin') {
-      throw new Error('유효하지 않은 사용자 역할입니다.');
-    }
-
     return {
-      role: profile.role,
+      role: normalizeRole(profile.role),
       user: {
         name: profile.name,
         grade: profile.grade ?? undefined,

--- a/src/services/auth/authSession.ts
+++ b/src/services/auth/authSession.ts
@@ -2,7 +2,9 @@ import { STORAGE_KEYS } from '@/constants/storageKeys';
 
 export type StoredAuthStatus = 'SIGNED_OUT' | 'SIGNUP_REQUIRED' | 'SIGNED_IN';
 
-const AUTH_STATUS_KEY = `${STORAGE_KEYS.accessToken}_status`;
+const isStoredAuthStatus = (value: string | null): value is StoredAuthStatus => {
+  return value === 'SIGNED_OUT' || value === 'SIGNUP_REQUIRED' || value === 'SIGNED_IN';
+};
 
 export const authSession = {
   getAccessToken: () => localStorage.getItem(STORAGE_KEYS.accessToken),
@@ -15,13 +17,9 @@ export const authSession = {
   },
 
   getAuthStatus: (): StoredAuthStatus => {
-    const storedAuthStatus = localStorage.getItem(AUTH_STATUS_KEY);
+    const storedAuthStatus = localStorage.getItem(STORAGE_KEYS.authStatus);
 
-    if (
-      storedAuthStatus === 'SIGNED_OUT' ||
-      storedAuthStatus === 'SIGNUP_REQUIRED' ||
-      storedAuthStatus === 'SIGNED_IN'
-    ) {
+    if (isStoredAuthStatus(storedAuthStatus)) {
       return storedAuthStatus;
     }
 
@@ -29,12 +27,12 @@ export const authSession = {
   },
 
   setAuthStatus: (authStatus: StoredAuthStatus) => {
-    localStorage.setItem(AUTH_STATUS_KEY, authStatus);
+    localStorage.setItem(STORAGE_KEYS.authStatus, authStatus);
   },
 
   clearSession: () => {
     localStorage.removeItem(STORAGE_KEYS.accessToken);
     localStorage.removeItem(STORAGE_KEYS.refreshToken);
-    localStorage.removeItem(AUTH_STATUS_KEY);
+    localStorage.removeItem(STORAGE_KEYS.authStatus);
   },
 };

--- a/src/services/http/interceptors.ts
+++ b/src/services/http/interceptors.ts
@@ -9,7 +9,11 @@ const AUTH_EXCLUDED_PATHS = [
   '/auth/teachers/signup',
 ];
 
-const shouldSkipUnauthorizedHandling = (url?: string) => {
+type AuthRequestConfig = InternalAxiosRequestConfig & {
+  skipUnauthorizedHandling?: boolean;
+};
+
+const shouldSkipUnauthorizedHandlingByPath = (url?: string) => {
   if (!url) {
     return false;
   }
@@ -23,17 +27,20 @@ const resetAuthState = () => {
 };
 
 const onRequest = (config: InternalAxiosRequestConfig) => {
+  const requestConfig = config as AuthRequestConfig;
   const accessToken = authSession.getAccessToken();
 
-  if (!config.headers) {
-    config.headers = new AxiosHeaders();
+  if (!requestConfig.headers) {
+    requestConfig.headers = new AxiosHeaders();
   }
 
-  if (accessToken) {
-    config.headers.Authorization = `Bearer ${accessToken}`;
+  const hasAuthorizationHeader = requestConfig.headers.has('Authorization');
+
+  if (!hasAuthorizationHeader && accessToken) {
+    requestConfig.headers.set('Authorization', `Bearer ${accessToken}`);
   }
 
-  return config;
+  return requestConfig;
 };
 
 const onRequestError = (error: AxiosError) => Promise.reject(error);
@@ -42,9 +49,13 @@ const onResponse = (response: AxiosResponse) => response;
 
 const onResponseError = (error: AxiosError) => {
   const status = error.response?.status;
-  const requestUrl = error.config?.url;
+  const requestConfig = error.config as AuthRequestConfig | undefined;
+  const requestUrl = requestConfig?.url;
 
-  if (status === 401 && !shouldSkipUnauthorizedHandling(requestUrl)) {
+  const shouldSkipUnauthorizedHandling =
+    requestConfig?.skipUnauthorizedHandling || shouldSkipUnauthorizedHandlingByPath(requestUrl);
+
+  if (status === 401 && !shouldSkipUnauthorizedHandling) {
     resetAuthState();
   }
 

--- a/src/types/icon.ts
+++ b/src/types/icon.ts
@@ -1,0 +1,3 @@
+import type { ComponentType, SVGProps } from 'react';
+
+export type IconComponent = ComponentType<SVGProps<SVGSVGElement>>;


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#3 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
관리자 로그인 기능 보완
인증 초기화 및 세션 처리 흐름 정리
로그인 화면에 사용할 공통 컴포넌트 구현
카카오 로그인 및 콜백 처리 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

### 인증 및 로그인 흐름
- 백엔드 role 응답값에 맞게 role 정규화 처리
- 관리자 로그인 엔드포인트 수정
- 관리자 로그인 시 로그인 응답만으로 완료 처리하지 않고, 사용자 정보 조회 및 role 검증까지 성공해야 최종 로그인되도록 수정
- 인증 에러 메시지 반환 구조를 title, description 형태로 정리
- 401 응답에서만 세션을 초기화하도록 수정
- 인증 초기화 및 세션 처리 동작 정리
- 인증 상태 조회 및 라우트 분기 구조 정리
- React Query 기본 조회 재시도 횟수 조정

### 카카오 로그인
- 카카오 로그인 및 콜백 처리 로직 분리 및 정리
- 카카오 로그인 에러 메시지 처리 구조 정리

### 공통 컴포넌트 및 UI
- TextField 공통 컴포넌트 구현
- IconButton 공통 컴포넌트 구현
- Alert 공통 컴포넌트 구현
- InlineButton이 기본 button props를 받을 수 있도록 확장
- copyright 문구를 공통 컴포넌트로 분리
- 관리자 로그인 화면에 공통 컴포넌트 적용 및 스타일 조정

### 기타
- IconComponent 타입을 공통 타입 파일로 이동

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
<img width="1502" height="863" alt="image" src="https://github.com/user-attachments/assets/80a208ca-6d16-40d3-bc6e-2da05d1cf577" />

<img width="538" height="561" alt="image" src="https://github.com/user-attachments/assets/54693b24-e1d9-4ed2-8691-a5c71bed9452" />
