### PR TITLE
[FEAT] 관리자 AI 모델 관리 페이지 성능 평가 섹션 구현 #17

### DIFF
--- a/src/components/admin/aiModel/ModelPerformanceSection.tsx
+++ b/src/components/admin/aiModel/ModelPerformanceSection.tsx
@@ -1,0 +1,112 @@
+import styled from '@emotion/styled';
+import { SectionCard } from '@/components/common/SectionCard';
+import { KpiCard } from '@/components/common/KpiCard';
+import { PerformanceChart } from './PerformanceChart';
+import { getPerformanceChartData } from '@/features/admin/aiModel/lib/performanceChartData';
+import { useModelEvaluation } from '@/features/admin/aiModel/hooks/useModelEvaluation';
+import { InlineButton } from '@/components/common/InlineButton';
+import { Alert } from '@/components/common/Alert';
+import { Loader } from '@/components/common/Loader';
+import { SectionEmptyState } from '@/components/common/SectionEmptyState';
+import { IcDashboard } from '@/icons';
+
+export const ModelPerformanceSection = () => {
+  const { evaluation, isInProgress, isLoading, isError, onRerun, isRerunning, rerunError } =
+    useModelEvaluation();
+
+  const headerAction = (
+    <InlineButton
+      variant="primary"
+      size="M"
+      label="다시 평가"
+      onClick={onRerun}
+      disabled={isRerunning}
+    />
+  );
+
+  if (isLoading) return <Loader />;
+
+  if (isError && !evaluation) {
+    return (
+      <SectionCard title="성능 평가" headerAction={headerAction}>
+        <ContentContainer>
+          <Alert title="성능 평가를 불러오지 못했어요" description="잠시 후 다시 시도해주세요." />
+        </ContentContainer>
+      </SectionCard>
+    );
+  }
+
+  if (!evaluation && !isInProgress) {
+    return (
+      <SectionCard title="성능 평가" headerAction={headerAction}>
+        <ContentContainer>
+          <SectionEmptyState
+            icon={IcDashboard}
+            title="성능 평가 데이터가 없어요"
+            description="평가를 먼저 진행해주세요."
+          />
+        </ContentContainer>
+      </SectionCard>
+    );
+  }
+
+  const chartData = evaluation ? getPerformanceChartData(evaluation) : [];
+
+  return (
+    <SectionCard title="성능 평가" headerAction={headerAction}>
+      {isInProgress && (
+        <ContentContainer>
+          <Alert
+            variant="success"
+            title="성능 평가를 진행 중이에요"
+            description="평가가 완료되면 최신 성능 지표를 확인할 수 있어요."
+          />
+        </ContentContainer>
+      )}
+
+      {rerunError && !isInProgress && (
+        <ContentContainer>
+          <Alert title="성능 평가를 시작하지 못했어요" description="잠시 후 다시 시도해주세요." />
+        </ContentContainer>
+      )}
+
+      {evaluation && (
+        <>
+          <KpiGrid>
+            <KpiCard title="Precision" value={(evaluation.precision * 100).toFixed(2) + '%'} />
+            <KpiCard title="Recall" value={(evaluation.recall * 100).toFixed(2) + '%'} />
+            <KpiCard title="F1-score" value={(evaluation.f1Score * 100).toFixed(2) + '%'} />
+          </KpiGrid>
+
+          <ChartWrapper>
+            <PerformanceChart data={chartData} />
+          </ChartWrapper>
+        </>
+      )}
+    </SectionCard>
+  );
+};
+
+const ContentContainer = styled.div`
+  padding: 16px 20px;
+`;
+
+const KpiGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 20px 16px;
+  gap: 16px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  @media (max-width: 480px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const ChartWrapper = styled.div`
+  width: 100%;
+  height: 240px;
+`;

--- a/src/components/admin/aiModel/PerformanceChart.tsx
+++ b/src/components/admin/aiModel/PerformanceChart.tsx
@@ -1,0 +1,56 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Rectangle,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import { chartColors } from '@/constants/chartColors';
+import type { ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import styled from '@emotion/styled';
+
+type Props = {
+  data: { label: string; value: number }[];
+};
+
+export const PerformanceChart = ({ data }: Props) => {
+  const getBarColor = (label: string) => {
+    if (label === 'Precision') return chartColors.performEvaluation.precision;
+    if (label === 'Recall') return chartColors.performEvaluation.recall;
+    return chartColors.performEvaluation.f1Score;
+  };
+
+  return (
+    <PerformanceChartContainer>
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={data} margin={{ top: 16, right: 20, left: 20, bottom: 16 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+          <YAxis domain={[0, 1]} width={32} tick={{ fontSize: 12 }} />
+          <Tooltip formatter={(value: ValueType | undefined) => `${Number(value).toFixed(2)}`} />
+          <Bar
+            dataKey="value"
+            barSize={48}
+            radius={[8, 8, 0, 0]}
+            shape={barProps => {
+              const fill = getBarColor(barProps.payload.label);
+              return <Rectangle {...barProps} fill={fill} />;
+            }}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </PerformanceChartContainer>
+  );
+};
+
+const PerformanceChartContainer = styled.div`
+  width: 100%;
+  height: 240px;
+
+  .recharts-wrapper *:focus {
+    outline: none;
+  }
+`;

--- a/src/components/admin/dashboard/PdfReportPanel.tsx
+++ b/src/components/admin/dashboard/PdfReportPanel.tsx
@@ -153,6 +153,10 @@ const PdfChartScrollArea = styled.div<{ $height: number; $isScrollable: boolean 
 const PdfChartInner = styled.div<{ $height: number }>`
   width: 100%;
   height: ${({ $height }) => `${$height}px`};
+
+  .recharts-wrapper *:focus {
+    outline: none;
+  }
 `;
 
 const PdfTable = styled.table`

--- a/src/components/admin/dashboard/RecommendationAdoptionPanel.tsx
+++ b/src/components/admin/dashboard/RecommendationAdoptionPanel.tsx
@@ -131,4 +131,8 @@ const KpiGrid = styled.div`
 const RecommendationChartContainer = styled.div`
   width: 100%;
   height: 180px;
+
+  .recharts-wrapper *:focus {
+    outline: none;
+  }
 `;

--- a/src/components/admin/dashboard/RiskDetectionPanel.tsx
+++ b/src/components/admin/dashboard/RiskDetectionPanel.tsx
@@ -124,6 +124,10 @@ const KpiGrid = styled.div`
 const RiskChartContainer = styled.div`
   width: 100%;
   height: 120px;
+
+  .recharts-wrapper *:focus {
+    outline: none;
+  }
 `;
 
 const LegendLabel = styled.span`

--- a/src/components/admin/dashboard/Tabs.tsx
+++ b/src/components/admin/dashboard/Tabs.tsx
@@ -54,7 +54,7 @@ const TabsContainer = styled.div`
   display: flex;
   overflow-x: auto;
   background-color: ${({ theme }) => theme.colors.background.bg1};
-  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border2};
   padding: 8px 12px 0;
   gap: 12px;
 

--- a/src/components/common/SectionCard.tsx
+++ b/src/components/common/SectionCard.tsx
@@ -28,14 +28,13 @@ const SectionCardContainer = styled.section`
   display: flex;
   min-width: 0;
   flex-direction: column;
-  border: 1px solid ${({ theme }) => theme.colors.border.border2};
   border-radius: 10px;
   background: ${({ theme }) => theme.colors.background.bg1};
 `;
 
 const SectionCardHeader = styled.div`
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   padding: 12px 20px;
   gap: 16px;

--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -53,9 +53,8 @@ const ToastStack = styled.div`
 `;
 
 const ToastCard = styled.button<{ toastType: ToastItem['type'] }>`
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  min-width: 220px;
   max-width: 360px;
   border-radius: 10px;
   border: 1px solid
@@ -96,7 +95,9 @@ const ToastStatusIcon = styled.span<{ toastType: ToastItem['type'] }>`
 `;
 
 const ToastMessage = styled.span`
+  flex: 1;
+  text-align: left;
   ${({ theme }) => theme.fonts.body3};
   color: ${({ theme }) => theme.colors.text.text1};
-  white-space: nowrap;
+  word-break: break-word;
 `;

--- a/src/constants/chartColors.ts
+++ b/src/constants/chartColors.ts
@@ -11,4 +11,9 @@ export const chartColors = {
   pdfReport: {
     primary: '#55B5A6',
   },
+  performEvaluation: {
+    precision: '#60CDE4',
+    recall: '#8F86F8',
+    f1Score: '#55B5A6',
+  },
 } as const;

--- a/src/features/admin/aiModel/hooks/useModelEvaluation.ts
+++ b/src/features/admin/aiModel/hooks/useModelEvaluation.ts
@@ -1,0 +1,92 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from 'react';
+import { useToast } from '@/hooks/useToast';
+import { aiModelApi } from '@/services/admin/aiModelApi';
+import type { Evaluation, EvaluationResponse } from '@/features/admin/aiModel/types/evaluation';
+
+export const useModelEvaluation = () => {
+  const { showToast } = useToast();
+  const queryClient = useQueryClient();
+
+  const prevStatusRef = useRef<Evaluation['status'] | null>(null);
+  const isRerunTriggeredRef = useRef(false);
+
+  const { data, isLoading, isError } = useQuery<EvaluationResponse>({
+    queryKey: ['modelEvaluation'],
+    queryFn: aiModelApi.getLatestEvaluation,
+
+    refetchInterval: query => {
+      const status = query.state.data?.data?.status;
+      return status === 'queued' || status === 'running' ? 3000 : false;
+    },
+  });
+
+  const evaluation: Evaluation | null = data?.data ?? null;
+  const status = evaluation?.status;
+
+  const isInProgress = status === 'queued' || status === 'running';
+  const isCompleted = status === 'completed';
+  const isFailed = status === 'failed';
+
+  useEffect(() => {
+    if (
+      isRerunTriggeredRef.current &&
+      prevStatusRef.current !== 'completed' &&
+      status === 'completed'
+    ) {
+      showToast('성능 평가가 완료되었어요', 'success');
+      isRerunTriggeredRef.current = false;
+    }
+
+    prevStatusRef.current = status ?? null;
+  }, [status, showToast]);
+
+  const rerunMutation = useMutation({
+    mutationFn: aiModelApi.rerunEvaluation,
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['modelEvaluation'],
+        exact: true,
+      });
+    },
+  });
+
+  const handleRerun = async () => {
+    if (rerunMutation.isPending || isInProgress) return;
+
+    const version = evaluation?.version;
+    if (!version) {
+      showToast('평가할 모델 버전 정보가 없어요', 'error');
+      return;
+    }
+
+    rerunMutation.reset();
+    isRerunTriggeredRef.current = true;
+
+    try {
+      await rerunMutation.mutateAsync({
+        version,
+        datasetVersion: 'v1.0',
+      });
+    } catch {
+      showToast('재평가 요청에 실패했어요', 'error');
+    }
+  };
+
+  return {
+    evaluation: isCompleted ? evaluation : null, // 👉 핵심
+    status,
+    isInProgress,
+    isCompleted,
+    isFailed,
+    isLoading,
+    isError,
+
+    onRerun: handleRerun,
+
+    isRerunning: rerunMutation.isPending || isInProgress,
+
+    rerunError: rerunMutation.isError,
+    resetRerunError: rerunMutation.reset,
+  };
+};

--- a/src/features/admin/aiModel/lib/performanceChartData.ts
+++ b/src/features/admin/aiModel/lib/performanceChartData.ts
@@ -1,0 +1,9 @@
+export const getPerformanceChartData = (data: {
+  precision: number;
+  recall: number;
+  f1Score: number;
+}) => [
+  { label: 'Precision', value: data.precision },
+  { label: 'Recall', value: data.recall },
+  { label: 'F1-score', value: data.f1Score },
+];

--- a/src/features/admin/aiModel/types/evaluation.ts
+++ b/src/features/admin/aiModel/types/evaluation.ts
@@ -1,0 +1,15 @@
+export type Evaluation = {
+  evaluationId: string;
+  precision: number;
+  recall: number;
+  f1Score: number;
+  status: 'queued' | 'running' | 'completed' | 'failed';
+  version: string;
+};
+
+export type EvaluationResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data: Evaluation;
+};

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -68,6 +68,7 @@ const Main = styled.div`
 `;
 
 const Content = styled.main`
+  overflow-x: hidden;
   overflow-y: auto;
   height: calc(100vh - ${HEADER_HEIGHT}px);
   min-height: 0;

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -68,8 +68,6 @@ const Main = styled.div`
 `;
 
 const Content = styled.main`
-  overflow-x: hidden;
-  overflow-y: auto;
   height: calc(100vh - ${HEADER_HEIGHT}px);
   min-height: 0;
   margin-top: ${HEADER_HEIGHT}px;

--- a/src/pages/admin/aiModel/AdminAiModelPage.tsx
+++ b/src/pages/admin/aiModel/AdminAiModelPage.tsx
@@ -1,11 +1,16 @@
 import styled from '@emotion/styled';
+import { ModelPerformanceSection } from '@/components/admin/aiModel/ModelPerformanceSection';
 
 export const AdminAiModelPage = () => {
-  return <AiModelPageContainer title="AI 모델 관리 페이지" />;
+  return (
+    <AiModelPageContainer title="AI 모델 관리 페이지">
+      <ModelPerformanceSection />
+    </AiModelPageContainer>
+  );
 };
 
 const AiModelPageContainer = styled.div`
   display: flex;
   flex-direction: column;
-  padding: 24px;
+  padding: 24px 16px;
 `;

--- a/src/services/admin/aiModelApi.ts
+++ b/src/services/admin/aiModelApi.ts
@@ -1,0 +1,13 @@
+import { apiClient } from '@/services/http/apiClient';
+
+export const aiModelApi = {
+  getLatestEvaluation: async () => {
+    const res = await apiClient.get('/admin/models/latest/evaluation');
+    return res.data;
+  },
+
+  rerunEvaluation: async (payload: { version: string; datasetVersion: string }) => {
+    const res = await apiClient.post('/admin/models/latest/evaluation/re-run', payload);
+    return res.data;
+  },
+};

--- a/src/styles/GlobalStyle.tsx
+++ b/src/styles/GlobalStyle.tsx
@@ -8,6 +8,8 @@ const globalStyles = css`
     -moz-osx-font-smoothing: grayscale;
     scrollbar-width: thin;
     scrollbar-color: #b2b2b2 transparent;
+    overflow-x: hidden;
+    overflow-y: auto;
   }
 
   html::-webkit-scrollbar,
@@ -58,7 +60,6 @@ const globalStyles = css`
     margin: 0;
     padding: 0;
     min-height: 100%;
-    overflow: hidden;
     background-color: #ffffff;
   }
 


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#17 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- AI 모델 성능 평가 기능 구현
- 성능 평가 섹션 관련 UI 구현
- 전역 레이아웃 구조 개선

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

### AI 모델 성능 평가 기능
- 모델 성능 평가 조회 API 연동
- 재평가(rerun) API 연동
- polling을 통한 평가 상태(queued, running) 반영
- 평가 상태 기반 UI 분기 처리 (진행중 / 실패 / 데이터 없음 / 완료)
- KPI 카드 및 성능 차트 구현
- 성능 평가 섹션 UI 구현

### 전역 스크롤 구조 개선
- GlobalStyle의 overflow: hidden 제거
- html(root)에 overflow-x: hidden, overflow-y: auto 적용
- 레이아웃 단위 스크롤 제거 및 구조 단순화

### UI 스타일 개선
- SectionCard 헤더 중앙 정렬 및 border 제거
- Tabs border 색상 수정
- Toast 메시지 좌측 정렬 및 줄바꿈 처리
- 차트 클릭 시 포커스 outline 제거
- Content 가로 스크롤 hidden 처리

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
<img width="1501" height="864" alt="image" src="https://github.com/user-attachments/assets/3f880835-1887-477e-bcc5-71e6c57c7936" />

<img width="1501" height="867" alt="image" src="https://github.com/user-attachments/assets/326d15b6-afd0-4090-9e97-95d0b44af76e" />

<img width="1501" height="866" alt="image" src="https://github.com/user-attachments/assets/d56ee23f-5373-40a7-914c-9353491250f4" />
