### PR TITLE
[FEAT] 관리자 로그아웃 구현 #19

### DIFF
--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 export const Loader = () => {
-  // TODO: 추후 스타일 수정
   return <Wrapper>Loading...</Wrapper>;
 };
 

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -7,13 +7,15 @@ import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
 import { useUiStore } from '@/stores/uiStore';
-import { IcBrandLogo, IcDefaultProfile } from '@/icons';
+import { IcBrandLogo, IcDefaultProfile, IcLogout } from '@/icons';
 import { SIDEBAR_WIDTH } from '@/constants/layout';
+import { useLogout } from '@/hooks/useLogout';
 
 export const Sidebar = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const { role, user } = useAuth();
+  const { logout } = useLogout();
   const isSidebarOpen = useUiStore(state => state.isSidebarOpen);
   const toggleSidebar = useUiStore(state => state.toggleSidebar);
   const items = role ? NAVIGATION_BY_ROLE[role] : [];
@@ -31,6 +33,10 @@ export const Sidebar = () => {
     }
 
     navigate(getDefaultRouteByRole(role), { replace: true });
+  };
+
+  const handleClickLogout = () => {
+    logout();
   };
 
   return (
@@ -93,7 +99,17 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {/* TODO: 로그아웃 버튼 */}
+        {role === 'admin' ? (
+          <LogoutIconButton
+            type="button"
+            isOpen={isSidebarOpen}
+            aria-label="로그아웃"
+            title="로그아웃"
+            onClick={handleClickLogout}
+          >
+            <IcLogout />
+          </LogoutIconButton>
+        ) : null}
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -293,4 +309,29 @@ const ProfileMeta = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.text.text4};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transform: ${({ isOpen }) => (isOpen ? 'translateX(0)' : 'translateX(-4px)')};
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease,
+    background-color 0.16s ease,
+    color 0.16s ease;
+  transition-delay: ${({ isOpen }) => (isOpen ? '120ms' : '0ms')};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.bg3};
+    color: ${({ theme }) => theme.colors.text.text1};
+  }
 `;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
 import { useAuth } from '@/hooks/useAuth';
 import { IconBadge } from '@/components/common/IconBadge';
+import { IconButton } from '@/components/common/IconButton';
 import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
@@ -99,17 +100,14 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {role === 'admin' ? (
-          <LogoutIconButton
-            type="button"
-            isOpen={isSidebarOpen}
-            aria-label="로그아웃"
-            title="로그아웃"
-            onClick={handleClickLogout}
-          >
-            <IcLogout />
-          </LogoutIconButton>
-        ) : null}
+        <LogoutButton
+          icon={IcLogout}
+          variant="plain"
+          isOpen={isSidebarOpen}
+          accessibilityLabel="로그아웃"
+          title="로그아웃"
+          onClick={handleClickLogout}
+        />
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -311,13 +309,11 @@ const ProfileMeta = styled.span`
   white-space: nowrap;
 `;
 
-const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+const LogoutButton = styled(IconButton)<{ isOpen: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 28px;
-  height: 28px;
   border-radius: 8px;
   color: ${({ theme }) => theme.colors.text.text4};
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};


### PR DESCRIPTION
#️⃣ Issue Number
#19

📝 요약(Summary)
관리자 사이드바 하단 프로필 영역에 로그아웃 아이콘 버튼을 추가하고, 클릭 시 즉시 로그아웃되도록 연결했습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

[✔️]새로운 기능 추가
[]버그 수정
[✔️]CSS 등 사용자 UI 디자인 변경
[]코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
[]코드 리팩토링
[]주석 추가 및 수정
[]문서 수정
[]테스트 추가, 테스트 리팩토링
[]빌드 부분 혹은 패키지 매니저 수정
[]파일 혹은 폴더명 수정
[]파일 혹은 폴더 삭제
✅ 변경사항
Sidebar 관리자 프로필 영역 우측에 로그아웃 아이콘 버튼 UI 추가
관리자(role === 'admin')일 때만 로그아웃 버튼 노출
로그아웃 버튼 클릭 시 useLogout 훅 호출 연결
별도 로그아웃 API 없이 기존 클라이언트 세션 정리 흐름(authSession.clearSession + 인증 상태 초기화 + 리다이렉트) 사용
📷 Screenshots or Video
<img width="353" height="127" alt="스크린샷 2026-04-27 004205" src="https://github.com/user-attachments/assets/ce8f7da0-7e44-4938-aa43-fb94f3c21684" />
<img width="2559" height="1242" alt="스크린샷 2026-04-27 004215" src="https://github.com/user-attachments/assets/9d56cd95-1a24-4251-bfa7-9586d5c72640" />
