### PR TITLE
[Fix]교사 설정 탭 버튼 비활성화 변경 #24

### DIFF
--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 export const Loader = () => {
-  // TODO: 추후 스타일 수정
   return <Wrapper>Loading...</Wrapper>;
 };
 

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -7,13 +7,15 @@ import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
 import { useUiStore } from '@/stores/uiStore';
-import { IcBrandLogo, IcDefaultProfile } from '@/icons';
+import { IcBrandLogo, IcDefaultProfile, IcLogout } from '@/icons';
 import { SIDEBAR_WIDTH } from '@/constants/layout';
+import { useLogout } from '@/hooks/useLogout';
 
 export const Sidebar = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const { role, user } = useAuth();
+  const { logout } = useLogout();
   const isSidebarOpen = useUiStore(state => state.isSidebarOpen);
   const toggleSidebar = useUiStore(state => state.toggleSidebar);
   const items = role ? NAVIGATION_BY_ROLE[role] : [];
@@ -31,6 +33,10 @@ export const Sidebar = () => {
     }
 
     navigate(getDefaultRouteByRole(role), { replace: true });
+  };
+
+  const handleClickLogout = () => {
+    logout();
   };
 
   return (
@@ -93,7 +99,17 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {/* TODO: 로그아웃 버튼 */}
+        {role === 'admin' ? (
+          <LogoutIconButton
+            type="button"
+            isOpen={isSidebarOpen}
+            aria-label="로그아웃"
+            title="로그아웃"
+            onClick={handleClickLogout}
+          >
+            <IcLogout />
+          </LogoutIconButton>
+        ) : null}
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -293,4 +309,29 @@ const ProfileMeta = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.text.text4};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transform: ${({ isOpen }) => (isOpen ? 'translateX(0)' : 'translateX(-4px)')};
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease,
+    background-color 0.16s ease,
+    color 0.16s ease;
+  transition-delay: ${({ isOpen }) => (isOpen ? '120ms' : '0ms')};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.bg3};
+    color: ${({ theme }) => theme.colors.text.text1};
+  }
 `;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
 import { useAuth } from '@/hooks/useAuth';
 import { IconBadge } from '@/components/common/IconBadge';
+import { IconButton } from '@/components/common/IconButton';
 import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
@@ -99,17 +100,14 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {role === 'admin' ? (
-          <LogoutIconButton
-            type="button"
-            isOpen={isSidebarOpen}
-            aria-label="로그아웃"
-            title="로그아웃"
-            onClick={handleClickLogout}
-          >
-            <IcLogout />
-          </LogoutIconButton>
-        ) : null}
+        <LogoutButton
+          icon={IcLogout}
+          variant="plain"
+          isOpen={isSidebarOpen}
+          accessibilityLabel="로그아웃"
+          title="로그아웃"
+          onClick={handleClickLogout}
+        />
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -311,13 +309,11 @@ const ProfileMeta = styled.span`
   white-space: nowrap;
 `;
 
-const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+const LogoutButton = styled(IconButton)<{ isOpen: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 28px;
-  height: 28px;
   border-radius: 8px;
   color: ${({ theme }) => theme.colors.text.text4};
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};

--- a/src/features/admin/aiModel/hooks/useModelEvaluation.ts
+++ b/src/features/admin/aiModel/hooks/useModelEvaluation.ts
@@ -74,7 +74,7 @@ export const useModelEvaluation = () => {
   };
 
   return {
-    evaluation: isCompleted ? evaluation : null, // 👉 핵심
+    evaluation: isCompleted ? evaluation : null,
     status,
     isInProgress,
     isCompleted,

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -447,37 +447,13 @@ export const TeacherSettingsPage = () => {
     }
   }, [hasWorkHoursChanges, isLoading, isSavingWorkHours, showToast, workdays]);
 
-  const headerActions = useMemo(
-    () => (
-      <>
-        <InlineButton
-          variant="ghost"
-          size="L"
-          label="취소"
-          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
-          onClick={handleResetWorkHours}
-        />
-        <InlineButton
-          variant="primary"
-          size="L"
-          label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
-          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
-          onClick={() => {
-            void handleSaveWorkHours();
-          }}
-        />
-      </>
-    ),
-    [handleResetWorkHours, handleSaveWorkHours, hasWorkHoursChanges, isLoading, isSavingWorkHours]
-  );
-
   useEffect(() => {
-    setHeaderActions(headerActions);
+    setHeaderActions(undefined);
 
     return () => {
       setHeaderActions(undefined);
     };
-  }, [headerActions, setHeaderActions]);
+  }, [setHeaderActions]);
 
   return (
     <PageContainer>
@@ -491,7 +467,27 @@ export const TeacherSettingsPage = () => {
         </CardSection>
 
         <CardSection>
-          <SectionTitle>근무시간 설정</SectionTitle>
+          <SectionHeader>
+            <SectionTitle>근무시간 설정</SectionTitle>
+            <SectionActionGroup>
+              <InlineButton
+                variant="ghost"
+                size="L"
+                label="취소"
+                disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
+                onClick={handleResetWorkHours}
+              />
+              <InlineButton
+                variant="primary"
+                size="L"
+                label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
+                disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
+                onClick={() => {
+                  void handleSaveWorkHours();
+                }}
+              />
+            </SectionActionGroup>
+          </SectionHeader>
           <SectionDescription>
             학부모님들이 메시지를 보낼 때 참고할 수 있는 시간이에요. 근무 시간 외에는 확인이 늦어질
             수 있다는 안내를 해드려요.
@@ -548,12 +544,16 @@ export const TeacherSettingsPage = () => {
         </CardSection>
 
         <CardSection>
-          <ClassHeader>
+          <SectionHeader>
             <SectionTitle>학급 관리</SectionTitle>
-            <PrimaryActionButton type="button" onClick={handleOpenClassChangeModal}>
-              학급 변경하기
-            </PrimaryActionButton>
-          </ClassHeader>
+            <InlineButton
+              type="button"
+              variant="primary"
+              size="L"
+              label="학급 변경하기"
+              onClick={handleOpenClassChangeModal}
+            />
+          </SectionHeader>
 
           <ClassInfoGrid>
             <InfoLabel>학교명</InfoLabel>
@@ -925,20 +925,17 @@ const RangeSeparator = styled.span`
   color: ${({ theme }) => theme.colors.text.text2};
 `;
 
-const ClassHeader = styled.div`
+const SectionHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 `;
 
-const PrimaryActionButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  border: none;
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.brand.primary};
-  color: ${({ theme }) => theme.colors.text.textW};
-  padding: 10px 14px;
+const SectionActionGroup = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 const ClassInfoGrid = styled.div`

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -330,18 +330,37 @@ export const TeacherSettingsPage = () => {
       })
     );
   };
+  const hasWorkHoursChanges = useMemo(() => {
+    if (initialWorkdays.length !== workdays.length) {
+      return true;
+    }
 
+    return workdays.some((day, index) => {
+      const initialDay = initialWorkdays[index];
+
+      if (!initialDay) {
+        return true;
+      }
+
+      return (
+        day.key !== initialDay.key ||
+        day.enabled !== initialDay.enabled ||
+        day.start !== initialDay.start ||
+        day.end !== initialDay.end
+      );
+    });
+  }, [initialWorkdays, workdays]);
   const handleResetWorkHours = useCallback(() => {
-    if (isLoading) {
+    if (isLoading || !hasWorkHoursChanges) {
       return;
     }
 
     setWorkdays(initialWorkdays);
     showToast('근무시간 입력값을 되돌렸어요.', 'success');
-  }, [initialWorkdays, isLoading, showToast]);
+  }, [hasWorkHoursChanges, initialWorkdays, isLoading, showToast]);
 
   const handleSaveWorkHours = useCallback(async () => {
-    if (isLoading || isSavingWorkHours) {
+    if (isLoading || isSavingWorkHours || !hasWorkHoursChanges) {
       return;
     }
 
@@ -426,7 +445,7 @@ export const TeacherSettingsPage = () => {
     } finally {
       setIsSavingWorkHours(false);
     }
-  }, [isLoading, isSavingWorkHours, showToast, workdays]);
+  }, [hasWorkHoursChanges, isLoading, isSavingWorkHours, showToast, workdays]);
 
   const headerActions = useMemo(
     () => (
@@ -435,21 +454,21 @@ export const TeacherSettingsPage = () => {
           variant="ghost"
           size="L"
           label="취소"
-          disabled={isLoading || isSavingWorkHours}
+          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
           onClick={handleResetWorkHours}
         />
         <InlineButton
           variant="primary"
           size="L"
           label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
-          disabled={isLoading || isSavingWorkHours}
+          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
           onClick={() => {
             void handleSaveWorkHours();
           }}
         />
       </>
     ),
-    [handleResetWorkHours, handleSaveWorkHours, isLoading, isSavingWorkHours]
+    [handleResetWorkHours, handleSaveWorkHours, hasWorkHoursChanges, isLoading, isSavingWorkHours]
   );
 
   useEffect(() => {

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -1,9 +1,6 @@
 import styled from '@emotion/styled';
-// import { useParams } from 'react-router-dom';
 
 export const TeacherThreadDetailPage = () => {
-  // const { threadId } = useParams();
-
   return <ThreadDetailPageContainer title="채팅방 페이지" />;
 };
 

--- a/src/utils/reports/intentMapper.ts
+++ b/src/utils/reports/intentMapper.ts
@@ -15,8 +15,6 @@ export const mapServerIntentType = (intentType?: string | null): IntentType | nu
   return serverIntentTypeMap[intentType] ?? null;
 };
 
-// Temporary fallback for environments where backend enum rollout is incomplete.
-// Remove this after intentType enum is stably provided by server.
 export const inferIntentTypeFromLabel = (label?: string | null): IntentType => {
   if (!label) {
     return 'request';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types="vite/client" />
-/// <reference types="vite-plugin-svgr/client" />
+import 'vite/client';
+import 'vite-plugin-svgr/client';


### PR DESCRIPTION
#️⃣ Issue Number
#24
📝 요약(Summary)
설정 화면에서 실제 변경사항이 없어도 취소, 변경사항 저장 버튼이 항상 활성화되던 문제를 수정했습니다.
초기 근무시간 상태와 현재 입력 상태를 비교해 변경이 있을 때만 버튼이 활성화되도록 하였습니다.
취소, 변경 버튼 위치를 근무시간 설정 섹션으로 이동하였습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

 - [ ]새로운 기능 추가
 - [X]버그 수정
 - [X]CSS 등 사용자 UI 디자인 변경
 - [ ]코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
 - [X]코드 리팩토링
 - [ ]주석 추가 및 수정
 - [ ]문서 수정
 - [ ]테스트 추가, 테스트 리팩토링
 - [ ]빌드 부분 혹은 패키지 매니저 수정
 - [ ]파일 혹은 폴더명 수정
 - [ ]파일 혹은 폴더 삭제
✅ 변경사항
TeacherSettingsPage에 hasWorkHoursChanges 계산 로직 추가
헤더 액션 버튼(취소, 변경사항 저장)의 disabled 조건에 변경 여부 반영
변경사항이 없을 때 handleResetWorkHours, handleSaveWorkHours가 실행되지 않도록 가드 추가
취소, 변경 버튼 위치를 근무시간 설정 섹션으로 이동
📷 [Screenshots]([url](url)) or Video

