### PR TITLE
[FEAT] 교사 로그아웃 구현 #26

### DIFF
--- a/src/components/admin/aiModel/PerformanceChart.tsx
+++ b/src/components/admin/aiModel/PerformanceChart.tsx
@@ -29,8 +29,8 @@ export const PerformanceChart = ({ data }: Props) => {
         <BarChart data={data} margin={{ top: 16, right: 20, left: 20, bottom: 16 }}>
           <CartesianGrid strokeDasharray="3 3" vertical={false} />
           <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-          <YAxis domain={[0, 1]} width={32} tick={{ fontSize: 12 }} />
-          <Tooltip formatter={(value: ValueType | undefined) => `${Number(value).toFixed(2)}`} />
+          <YAxis domain={[0, 100]} width={32} tick={{ fontSize: 12 }} />
+          <Tooltip formatter={(value: ValueType | undefined) => `${Number(value).toFixed(2)}%`} />
           <Bar
             dataKey="value"
             barSize={48}

--- a/src/components/common/Loader.tsx
+++ b/src/components/common/Loader.tsx
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 export const Loader = () => {
-  // TODO: 추후 스타일 수정
   return <Wrapper>Loading...</Wrapper>;
 };
 

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -2,36 +2,33 @@ import styled from '@emotion/styled';
 import { NavLink, useNavigate } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
 import { useAuth } from '@/hooks/useAuth';
+import { useLogout } from '@/hooks/useLogout';
 import { IconBadge } from '@/components/common/IconBadge';
+import { IconButton } from '@/components/common/IconButton';
 import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
-import { ROUTES } from '@/constants/routes';
 import { useUiStore } from '@/stores/uiStore';
-import { IcBrandLogo, IcDefaultProfile } from '@/icons';
+import { IcBrandLogo, IcDefaultProfile, IcLogout } from '@/icons';
 import { SIDEBAR_WIDTH } from '@/constants/layout';
 
 export const Sidebar = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const { role, user } = useAuth();
+  const { logout } = useLogout();
   const isSidebarOpen = useUiStore(state => state.isSidebarOpen);
   const toggleSidebar = useUiStore(state => state.toggleSidebar);
-  const items = role ? NAVIGATION_BY_ROLE[role] : [];
+  const items = NAVIGATION_BY_ROLE[role ?? 'teacher'];
 
   const userName = user?.name ?? '사용자';
   const userMeta =
-    role === 'teacher' && user?.grade && user?.classNumber
-      ? `${user.grade}학년 ${user.classNumber}반`
-      : '';
+    user?.grade && user?.classNumber ? `${user.grade}학년 ${user.classNumber}반` : '';
 
   const handleClickBrand = () => {
-    if (!role) {
-      navigate(ROUTES.root, { replace: true });
-      return;
-    }
-
     navigate(getDefaultRouteByRole(role), { replace: true });
   };
+
+  const handleLogout = () => logout();
 
   return (
     <SidebarContainer isOpen={isSidebarOpen}>
@@ -93,7 +90,14 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {/* TODO: 로그아웃 버튼 */}
+        {isSidebarOpen ? (
+          <LogoutButton
+            icon={IcLogout}
+            variant="plain"
+            accessibilityLabel="로그아웃"
+            onClick={handleLogout}
+          />
+        ) : null}
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -293,4 +297,23 @@ const ProfileMeta = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+const LogoutButton = styled(IconButton)`
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  margin-left: auto;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.text.text4};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.bg3};
+    color: ${({ theme }) => theme.colors.text.text1};
+  }
+
+  &:focus-visible {
+    outline: 2px solid ${({ theme }) => theme.colors.brand.primary};
+    outline-offset: 2px;
+  }
 `;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -100,14 +100,15 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        <LogoutButton
-          icon={IcLogout}
-          variant="plain"
-          isOpen={isSidebarOpen}
-          accessibilityLabel="로그아웃"
-          title="로그아웃"
-          onClick={handleClickLogout}
-        />
+        <LogoutButtonSlot isOpen={isSidebarOpen}>
+          <IconButton
+            icon={IcLogout}
+            variant="plain"
+            accessibilityLabel="로그아웃"
+            title="로그아웃"
+            onClick={handleClickLogout}
+          />
+        </LogoutButtonSlot>
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -309,25 +310,17 @@ const ProfileMeta = styled.span`
   white-space: nowrap;
 `;
 
-const LogoutButton = styled(IconButton)<{ isOpen: boolean }>`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+const LogoutButtonSlot = styled.div<{ isOpen: boolean }>`
+  overflow: hidden;
   flex-shrink: 0;
-  border-radius: 8px;
-  color: ${({ theme }) => theme.colors.text.text4};
+  width: ${({ isOpen }) => (isOpen ? '40px' : '0')};
+  max-width: ${({ isOpen }) => (isOpen ? '40px' : '0')};
+  height: ${({ isOpen }) => (isOpen ? '40px' : '0')};
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
   pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
   transform: ${({ isOpen }) => (isOpen ? 'translateX(0)' : 'translateX(-4px)')};
   transition:
     opacity 0.16s ease,
-    transform 0.16s ease,
-    background-color 0.16s ease,
-    color 0.16s ease;
+    transform 0.16s ease;
   transition-delay: ${({ isOpen }) => (isOpen ? '120ms' : '0ms')};
-
-  &:hover {
-    background: ${({ theme }) => theme.colors.background.bg3};
-    color: ${({ theme }) => theme.colors.text.text1};
-  }
 `;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -7,13 +7,15 @@ import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
 import { useUiStore } from '@/stores/uiStore';
-import { IcBrandLogo, IcDefaultProfile } from '@/icons';
+import { IcBrandLogo, IcDefaultProfile, IcLogout } from '@/icons';
 import { SIDEBAR_WIDTH } from '@/constants/layout';
+import { useLogout } from '@/hooks/useLogout';
 
 export const Sidebar = () => {
   const theme = useTheme();
   const navigate = useNavigate();
   const { role, user } = useAuth();
+  const { logout } = useLogout();
   const isSidebarOpen = useUiStore(state => state.isSidebarOpen);
   const toggleSidebar = useUiStore(state => state.toggleSidebar);
   const items = role ? NAVIGATION_BY_ROLE[role] : [];
@@ -31,6 +33,10 @@ export const Sidebar = () => {
     }
 
     navigate(getDefaultRouteByRole(role), { replace: true });
+  };
+
+  const handleClickLogout = () => {
+    logout();
   };
 
   return (
@@ -93,7 +99,17 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {/* TODO: 로그아웃 버튼 */}
+        {role === 'admin' ? (
+          <LogoutIconButton
+            type="button"
+            isOpen={isSidebarOpen}
+            aria-label="로그아웃"
+            title="로그아웃"
+            onClick={handleClickLogout}
+          >
+            <IcLogout />
+          </LogoutIconButton>
+        ) : null}
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -293,4 +309,29 @@ const ProfileMeta = styled.span`
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+`;
+
+const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  color: ${({ theme }) => theme.colors.text.text4};
+  opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};
+  pointer-events: ${({ isOpen }) => (isOpen ? 'auto' : 'none')};
+  transform: ${({ isOpen }) => (isOpen ? 'translateX(0)' : 'translateX(-4px)')};
+  transition:
+    opacity 0.16s ease,
+    transform 0.16s ease,
+    background-color 0.16s ease,
+    color 0.16s ease;
+  transition-delay: ${({ isOpen }) => (isOpen ? '120ms' : '0ms')};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.bg3};
+    color: ${({ theme }) => theme.colors.text.text1};
+  }
 `;

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useNavigate } from 'react-router-dom';
 import { useTheme } from '@emotion/react';
 import { useAuth } from '@/hooks/useAuth';
 import { IconBadge } from '@/components/common/IconBadge';
+import { IconButton } from '@/components/common/IconButton';
 import { getDefaultRouteByRole } from '@/utils/getDefaultRouteByRole';
 import { NAVIGATION_BY_ROLE } from '@/constants/navigation';
 import { ROUTES } from '@/constants/routes';
@@ -99,17 +100,14 @@ export const Sidebar = () => {
             {userMeta && <ProfileMeta>{userMeta}</ProfileMeta>}
           </ProfileSummary>
         </ProfileSummarySlot>
-        {role === 'admin' ? (
-          <LogoutIconButton
-            type="button"
-            isOpen={isSidebarOpen}
-            aria-label="로그아웃"
-            title="로그아웃"
-            onClick={handleClickLogout}
-          >
-            <IcLogout />
-          </LogoutIconButton>
-        ) : null}
+        <LogoutButton
+          icon={IcLogout}
+          variant="plain"
+          isOpen={isSidebarOpen}
+          accessibilityLabel="로그아웃"
+          title="로그아웃"
+          onClick={handleClickLogout}
+        />
       </SidebarProfileSection>
     </SidebarContainer>
   );
@@ -311,13 +309,11 @@ const ProfileMeta = styled.span`
   white-space: nowrap;
 `;
 
-const LogoutIconButton = styled.button<{ isOpen: boolean }>`
+const LogoutButton = styled(IconButton)<{ isOpen: boolean }>`
   display: inline-flex;
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: 28px;
-  height: 28px;
   border-radius: 8px;
   color: ${({ theme }) => theme.colors.text.text4};
   opacity: ${({ isOpen }) => (isOpen ? 1 : 0)};

--- a/src/features/admin/aiModel/hooks/useModelEvaluation.ts
+++ b/src/features/admin/aiModel/hooks/useModelEvaluation.ts
@@ -74,7 +74,7 @@ export const useModelEvaluation = () => {
   };
 
   return {
-    evaluation: isCompleted ? evaluation : null, // 👉 핵심
+    evaluation: isCompleted ? evaluation : null,
     status,
     isInProgress,
     isCompleted,

--- a/src/features/admin/aiModel/lib/performanceChartData.ts
+++ b/src/features/admin/aiModel/lib/performanceChartData.ts
@@ -3,7 +3,7 @@ export const getPerformanceChartData = (data: {
   recall: number;
   f1Score: number;
 }) => [
-  { label: 'Precision', value: data.precision },
-  { label: 'Recall', value: data.recall },
-  { label: 'F1-score', value: data.f1Score },
+  { label: 'Precision', value: data.precision * 100 },
+  { label: 'Recall', value: data.recall * 100 },
+  { label: 'F1-score', value: data.f1Score * 100 },
 ];

--- a/src/features/admin/dashboard/hooks/useAdminDashboard.ts
+++ b/src/features/admin/dashboard/hooks/useAdminDashboard.ts
@@ -15,33 +15,24 @@ export const useAdminDashboard = () => {
   const recommendationQuery = useQuery({
     queryKey: DASHBOARD_QUERY_KEYS.recommendation,
     queryFn: dashboardApi.getRecommendationStatistics,
-    enabled: activeTab === 'recommendation',
     staleTime: 1000 * 60 * 5,
   });
 
   const riskQuery = useQuery({
     queryKey: DASHBOARD_QUERY_KEYS.risk,
     queryFn: dashboardApi.getRiskStatistics,
-    enabled: activeTab === 'risk',
     staleTime: 1000 * 60 * 5,
   });
 
   const pdfQuery = useQuery({
     queryKey: DASHBOARD_QUERY_KEYS.pdf,
     queryFn: dashboardApi.getPdfStatistics,
-    enabled: activeTab === 'pdf',
     staleTime: 1000 * 60 * 5,
   });
 
   const currentQuery = useMemo(() => {
-    if (activeTab === 'recommendation') {
-      return recommendationQuery;
-    }
-
-    if (activeTab === 'risk') {
-      return riskQuery;
-    }
-
+    if (activeTab === 'recommendation') return recommendationQuery;
+    if (activeTab === 'risk') return riskQuery;
     return pdfQuery;
   }, [activeTab, recommendationQuery, riskQuery, pdfQuery]);
 

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -6,6 +6,7 @@ import { InlineButton } from '@/components/common/InlineButton';
 import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
 import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
 import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
+import { useLogout } from '@/hooks/useLogout';
 import { useToast } from '@/hooks/useToast';
 
 type WorkdayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
@@ -107,6 +108,7 @@ const extractClassNumber = (raw: string) => {
 
 export const TeacherSettingsPage = () => {
   const { showToast } = useToast();
+  const { logout } = useLogout();
   const { setHeaderActions } = useOutletContext<AppLayoutOutletContext>();
   const [setting, setSetting] = useState<TeacherSetting | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -125,6 +127,7 @@ export const TeacherSettingsPage = () => {
   const [initialWorkdays, setInitialWorkdays] = useState<Workday[]>([]);
   const [workdays, setWorkdays] = useState<Workday[]>([]);
   const [isSavingWorkHours, setIsSavingWorkHours] = useState(false);
+  const handleLogout = () => logout();
 
   useEffect(() => {
     let isMounted = true;
@@ -570,7 +573,9 @@ export const TeacherSettingsPage = () => {
         <CardSection>
           <SectionTitle>계정 관리</SectionTitle>
           <AccountLinkList>
-            <AccountLinkButton type="button">로그아웃</AccountLinkButton>
+            <AccountLinkButton type="button" onClick={handleLogout}>
+              로그아웃
+            </AccountLinkButton>
             <DangerLinkButton type="button">회원 탈퇴</DangerLinkButton>
           </AccountLinkList>
         </CardSection>

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -447,37 +447,13 @@ export const TeacherSettingsPage = () => {
     }
   }, [hasWorkHoursChanges, isLoading, isSavingWorkHours, showToast, workdays]);
 
-  const headerActions = useMemo(
-    () => (
-      <>
-        <InlineButton
-          variant="ghost"
-          size="L"
-          label="취소"
-          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
-          onClick={handleResetWorkHours}
-        />
-        <InlineButton
-          variant="primary"
-          size="L"
-          label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
-          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
-          onClick={() => {
-            void handleSaveWorkHours();
-          }}
-        />
-      </>
-    ),
-    [handleResetWorkHours, handleSaveWorkHours, hasWorkHoursChanges, isLoading, isSavingWorkHours]
-  );
-
   useEffect(() => {
-    setHeaderActions(headerActions);
+    setHeaderActions(undefined);
 
     return () => {
       setHeaderActions(undefined);
     };
-  }, [headerActions, setHeaderActions]);
+  }, [setHeaderActions]);
 
   return (
     <PageContainer>
@@ -491,7 +467,27 @@ export const TeacherSettingsPage = () => {
         </CardSection>
 
         <CardSection>
-          <SectionTitle>근무시간 설정</SectionTitle>
+          <SectionHeader>
+            <SectionTitle>근무시간 설정</SectionTitle>
+            <SectionActionGroup>
+              <InlineButton
+                variant="ghost"
+                size="L"
+                label="취소"
+                disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
+                onClick={handleResetWorkHours}
+              />
+              <InlineButton
+                variant="primary"
+                size="L"
+                label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
+                disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
+                onClick={() => {
+                  void handleSaveWorkHours();
+                }}
+              />
+            </SectionActionGroup>
+          </SectionHeader>
           <SectionDescription>
             학부모님들이 메시지를 보낼 때 참고할 수 있는 시간이에요. 근무 시간 외에는 확인이 늦어질
             수 있다는 안내를 해드려요.
@@ -548,12 +544,16 @@ export const TeacherSettingsPage = () => {
         </CardSection>
 
         <CardSection>
-          <ClassHeader>
+          <SectionHeader>
             <SectionTitle>학급 관리</SectionTitle>
-            <PrimaryActionButton type="button" onClick={handleOpenClassChangeModal}>
-              학급 변경하기
-            </PrimaryActionButton>
-          </ClassHeader>
+            <InlineButton
+              type="button"
+              variant="primary"
+              size="L"
+              label="학급 변경하기"
+              onClick={handleOpenClassChangeModal}
+            />
+          </SectionHeader>
 
           <ClassInfoGrid>
             <InfoLabel>학교명</InfoLabel>
@@ -925,20 +925,17 @@ const RangeSeparator = styled.span`
   color: ${({ theme }) => theme.colors.text.text2};
 `;
 
-const ClassHeader = styled.div`
+const SectionHeader = styled.div`
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 12px;
 `;
 
-const PrimaryActionButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  border: none;
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.brand.primary};
-  color: ${({ theme }) => theme.colors.text.textW};
-  padding: 10px 14px;
+const SectionActionGroup = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
 `;
 
 const ClassInfoGrid = styled.div`

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -330,18 +330,37 @@ export const TeacherSettingsPage = () => {
       })
     );
   };
+  const hasWorkHoursChanges = useMemo(() => {
+    if (initialWorkdays.length !== workdays.length) {
+      return true;
+    }
 
+    return workdays.some((day, index) => {
+      const initialDay = initialWorkdays[index];
+
+      if (!initialDay) {
+        return true;
+      }
+
+      return (
+        day.key !== initialDay.key ||
+        day.enabled !== initialDay.enabled ||
+        day.start !== initialDay.start ||
+        day.end !== initialDay.end
+      );
+    });
+  }, [initialWorkdays, workdays]);
   const handleResetWorkHours = useCallback(() => {
-    if (isLoading) {
+    if (isLoading || !hasWorkHoursChanges) {
       return;
     }
 
     setWorkdays(initialWorkdays);
     showToast('근무시간 입력값을 되돌렸어요.', 'success');
-  }, [initialWorkdays, isLoading, showToast]);
+  }, [hasWorkHoursChanges, initialWorkdays, isLoading, showToast]);
 
   const handleSaveWorkHours = useCallback(async () => {
-    if (isLoading || isSavingWorkHours) {
+    if (isLoading || isSavingWorkHours || !hasWorkHoursChanges) {
       return;
     }
 
@@ -426,7 +445,7 @@ export const TeacherSettingsPage = () => {
     } finally {
       setIsSavingWorkHours(false);
     }
-  }, [isLoading, isSavingWorkHours, showToast, workdays]);
+  }, [hasWorkHoursChanges, isLoading, isSavingWorkHours, showToast, workdays]);
 
   const headerActions = useMemo(
     () => (
@@ -435,21 +454,21 @@ export const TeacherSettingsPage = () => {
           variant="ghost"
           size="L"
           label="취소"
-          disabled={isLoading || isSavingWorkHours}
+          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
           onClick={handleResetWorkHours}
         />
         <InlineButton
           variant="primary"
           size="L"
           label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
-          disabled={isLoading || isSavingWorkHours}
+          disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
           onClick={() => {
             void handleSaveWorkHours();
           }}
         />
       </>
     ),
-    [handleResetWorkHours, handleSaveWorkHours, isLoading, isSavingWorkHours]
+    [handleResetWorkHours, handleSaveWorkHours, hasWorkHoursChanges, isLoading, isSavingWorkHours]
   );
 
   useEffect(() => {

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -6,6 +6,7 @@ import { InlineButton } from '@/components/common/InlineButton';
 import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
 import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
 import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
+import { useLogout } from '@/hooks/useLogout';
 import { useToast } from '@/hooks/useToast';
 
 type WorkdayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
@@ -107,6 +108,7 @@ const extractClassNumber = (raw: string) => {
 
 export const TeacherSettingsPage = () => {
   const { showToast } = useToast();
+  const { logout } = useLogout();
   const { setHeaderActions } = useOutletContext<AppLayoutOutletContext>();
   const [setting, setSetting] = useState<TeacherSetting | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -125,6 +127,7 @@ export const TeacherSettingsPage = () => {
   const [initialWorkdays, setInitialWorkdays] = useState<Workday[]>([]);
   const [workdays, setWorkdays] = useState<Workday[]>([]);
   const [isSavingWorkHours, setIsSavingWorkHours] = useState(false);
+  const handleLogout = () => logout();
 
   useEffect(() => {
     let isMounted = true;
@@ -589,7 +592,9 @@ export const TeacherSettingsPage = () => {
         <CardSection>
           <SectionTitle>계정 관리</SectionTitle>
           <AccountLinkList>
-            <AccountLinkButton type="button">로그아웃</AccountLinkButton>
+            <AccountLinkButton type="button" onClick={handleLogout}>
+              로그아웃
+            </AccountLinkButton>
             <DangerLinkButton type="button">회원 탈퇴</DangerLinkButton>
           </AccountLinkList>
         </CardSection>

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -1,9 +1,6 @@
 import styled from '@emotion/styled';
-// import { useParams } from 'react-router-dom';
 
 export const TeacherThreadDetailPage = () => {
-  // const { threadId } = useParams();
-
   return <ThreadDetailPageContainer title="채팅방 페이지" />;
 };
 

--- a/src/utils/reports/intentMapper.ts
+++ b/src/utils/reports/intentMapper.ts
@@ -15,8 +15,6 @@ export const mapServerIntentType = (intentType?: string | null): IntentType | nu
   return serverIntentTypeMap[intentType] ?? null;
 };
 
-// Temporary fallback for environments where backend enum rollout is incomplete.
-// Remove this after intentType enum is stably provided by server.
 export const inferIntentTypeFromLabel = (label?: string | null): IntentType => {
   if (!label) {
     return 'request';

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,2 +1,2 @@
-/// <reference types="vite/client" />
-/// <reference types="vite-plugin-svgr/client" />
+import 'vite/client';
+import 'vite-plugin-svgr/client';


### PR DESCRIPTION
#️⃣ Issue Number
#26

📝 요약(Summary)
교사 설정 페이지와 사이드바에서 로그아웃 기능이 실제로 동작하도록 연결했습니다.
사용자가 계정 관리/프로필 영역 어디서든 일관되게 로그아웃할 수 있도록 UX를 보완했고, 사이드바 로그아웃 버튼은 공통 IconButton 컴포넌트를 사용하도록 정리했습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

  -[X]새로운 기능 추가
  -[ ]버그 수정
  -[X]CSS 등 사용자 UI 디자인 변경
  -[ ]코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
  -[X]코드 리팩토링
  -[ ]주석 추가 및 수정
  -[ ]문서 수정
  -[ ]테스트 추가, 테스트 리팩토링
  -[ ]빌드 부분 혹은 패키지 매니저 수정
  -[ ]파일 혹은 폴더명 수정
  -[ ]파일 혹은 폴더 삭제
✅ 변경사항
교사 설정 페이지 계정 관리 > 로그아웃 버튼 클릭 시 useLogout 훅으로 로그아웃 수행
사이드바 교사 프로필 우측에 로그아웃 아이콘 버튼 추가
사이드바 로그아웃 버튼을 공통 IconButton 기반으로 적용
사이드바 내 불필요한 role 분기 로직 정리
📷 Screenshots or Video

<img width="390" height="112" alt="스크린샷 2026-04-27 082733" src="https://github.com/user-attachments/assets/e105e8c7-566c-4c4b-a96c-00bbc0700551" />
<img width="1519" height="238" alt="스크린샷 2026-04-27 082755" src="https://github.com/user-attachments/assets/2105bf3f-7d5b-4cc2-b587-340d39397523" />

