### PR TITLE
[FEAT]채팅방 목록 조회/채팅상세내역 조회#30

### DIFF
--- a/src/components/common/Dialog.tsx
+++ b/src/components/common/Dialog.tsx
@@ -78,7 +78,7 @@ const DialogOverlay = styled.div`
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: ${({ theme }) => theme.colors.overlay.dim1};
+  background: ${({ theme }) => theme.colors.overlay.dim};
 
   @media (max-width: 393px) {
     padding: 16px;

--- a/src/components/common/chat/ChatComposer.tsx
+++ b/src/components/common/chat/ChatComposer.tsx
@@ -1,0 +1,79 @@
+﻿import styled from '@emotion/styled';
+import { IconButton } from '@/components/common/IconButton';
+import { IcSend, IcSparkles } from '@/icons';
+
+type ComposerActionMode = 'assist' | 'send';
+
+type ChatComposerProps = {
+  value: string;
+  placeholder?: string;
+  onChange: (nextValue: string) => void;
+  onActionClick?: () => void;
+  actionMode?: ComposerActionMode;
+  isActionDisabled?: boolean;
+};
+
+export const ChatComposer = ({
+  value,
+  placeholder = '학부모님께 전달할 답변을 작성해주세요.',
+  onChange,
+  onActionClick,
+  actionMode = 'assist',
+  isActionDisabled = false,
+}: ChatComposerProps) => {
+  const actionIcon = actionMode === 'send' ? IcSend : IcSparkles;
+  const actionLabel = actionMode === 'send' ? '메시지 전송' : 'AI 소통 어시스턴트';
+  const actionVariant = isActionDisabled ? 'ghost' : 'primary';
+
+  return (
+    <ComposerContainer>
+      <ComposerInput
+        value={value}
+        placeholder={placeholder}
+        onChange={event => onChange(event.target.value)}
+      />
+      <ActionButtonWrap>
+        <IconButton
+          icon={actionIcon}
+          variant={actionVariant}
+          accessibilityLabel={actionLabel}
+          disabled={isActionDisabled}
+          onClick={onActionClick}
+        />
+      </ActionButtonWrap>
+    </ComposerContainer>
+  );
+};
+
+const ComposerContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  padding: 10px 12px;
+`;
+
+const ComposerInput = styled.input`
+  ${({ theme }) => theme.fonts.body2};
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: ${({ theme }) => theme.colors.text.text1};
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.text4};
+  }
+
+  &:focus {
+    outline: none;
+  }
+`;
+
+const ActionButtonWrap = styled.div`
+  button {
+    width: 36px;
+    height: 36px;
+  }
+`;

--- a/src/components/common/chat/ChatComposer.tsx
+++ b/src/components/common/chat/ChatComposer.tsx
@@ -27,7 +27,7 @@ export const ChatComposer = ({
 
   return (
     <ComposerContainer>
-      <ComposerInput
+      <ComposerTextarea
         value={value}
         placeholder={placeholder}
         onChange={event => onChange(event.target.value)}
@@ -47,7 +47,7 @@ export const ChatComposer = ({
 
 const ComposerContainer = styled.div`
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 12px;
   border: 1px solid ${({ theme }) => theme.colors.border.border1};
   border-radius: 12px;
@@ -55,12 +55,16 @@ const ComposerContainer = styled.div`
   padding: 10px 12px;
 `;
 
-const ComposerInput = styled.input`
+const ComposerTextarea = styled.textarea`
   ${({ theme }) => theme.fonts.body2};
   flex: 1;
   border: none;
   background: transparent;
   color: ${({ theme }) => theme.colors.text.text1};
+  resize: none;
+  min-height: 24px;
+  max-height: 132px;
+  line-height: 1.5;
 
   &::placeholder {
     color: ${({ theme }) => theme.colors.text.text4};

--- a/src/components/common/chat/StatusTagButton.tsx
+++ b/src/components/common/chat/StatusTagButton.tsx
@@ -1,7 +1,7 @@
 ﻿import styled from '@emotion/styled';
 import { IcDown } from '@/icons';
 
-export type StatusTagTone = 'processing' | 'done' | 'absence';
+export type StatusTagTone = 'processing' | 'done' | 'hold' | 'absence';
 
 type StatusTagButtonProps = {
   label: string;
@@ -35,16 +35,19 @@ const TagButton = styled.button<{ $tone: StatusTagTone }>`
     ${({ $tone }) => {
       if ($tone === 'absence') return '#E8B16E';
       if ($tone === 'processing') return '#8FCBC2';
+      if ($tone === 'hold') return '#CBB8FF';
       return '#BFC7D4';
     }};
   background: ${({ $tone }) => {
     if ($tone === 'absence') return '#FFF2E2';
     if ($tone === 'processing') return '#E6F7F2';
+    if ($tone === 'hold') return '#F2ECFF';
     return '#F3F5F8';
   }};
   color: ${({ $tone }) => {
     if ($tone === 'absence') return '#C56A17';
     if ($tone === 'processing') return '#3E8D80';
+    if ($tone === 'hold') return '#6F53B8';
     return '#586072';
   }};
 

--- a/src/components/common/chat/StatusTagButton.tsx
+++ b/src/components/common/chat/StatusTagButton.tsx
@@ -32,23 +32,23 @@ const TagButton = styled.button<{ $tone: StatusTagTone }>`
   border-radius: 999px;
   padding: 4px 10px;
   border: 1px solid
-    ${({ $tone }) => {
-      if ($tone === 'absence') return '#E8B16E';
-      if ($tone === 'processing') return '#8FCBC2';
-      if ($tone === 'hold') return '#CBB8FF';
-      return '#BFC7D4';
+    ${({ $tone, theme }) => {
+      if ($tone === 'absence') return theme.colors.intent.absenceLate.border;
+      if ($tone === 'processing') return theme.colors.threadStatus.processing.border;
+      if ($tone === 'hold') return theme.colors.intent.request.border;
+      return theme.colors.threadStatus.completed.border;
     }};
-  background: ${({ $tone }) => {
-    if ($tone === 'absence') return '#FFF2E2';
-    if ($tone === 'processing') return '#E6F7F2';
-    if ($tone === 'hold') return '#F2ECFF';
-    return '#F3F5F8';
+  background: ${({ $tone, theme }) => {
+    if ($tone === 'absence') return theme.colors.intent.absenceLate.background;
+    if ($tone === 'processing') return theme.colors.threadStatus.processing.background;
+    if ($tone === 'hold') return theme.colors.intent.request.background;
+    return theme.colors.threadStatus.completed.background;
   }};
-  color: ${({ $tone }) => {
-    if ($tone === 'absence') return '#C56A17';
-    if ($tone === 'processing') return '#3E8D80';
-    if ($tone === 'hold') return '#6F53B8';
-    return '#586072';
+  color: ${({ $tone, theme }) => {
+    if ($tone === 'absence') return theme.colors.intent.absenceLate.text;
+    if ($tone === 'processing') return theme.colors.threadStatus.processing.text;
+    if ($tone === 'hold') return theme.colors.intent.request.text;
+    return theme.colors.threadStatus.completed.text;
   }};
 
   svg {

--- a/src/components/common/chat/StatusTagButton.tsx
+++ b/src/components/common/chat/StatusTagButton.tsx
@@ -1,0 +1,55 @@
+﻿import styled from '@emotion/styled';
+import { IcDown } from '@/icons';
+
+export type StatusTagTone = 'processing' | 'done' | 'absence';
+
+type StatusTagButtonProps = {
+  label: string;
+  tone: StatusTagTone;
+  isDropdown?: boolean;
+  onClick?: () => void;
+};
+
+export const StatusTagButton = ({
+  label,
+  tone,
+  isDropdown = false,
+  onClick,
+}: StatusTagButtonProps) => {
+  return (
+    <TagButton type="button" $tone={tone} onClick={onClick}>
+      <span>{label}</span>
+      {isDropdown ? <IcDown /> : null}
+    </TagButton>
+  );
+};
+
+const TagButton = styled.button<{ $tone: StatusTagTone }>`
+  ${({ theme }) => theme.fonts.labelXS};
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border-radius: 999px;
+  padding: 4px 10px;
+  border: 1px solid
+    ${({ $tone }) => {
+      if ($tone === 'absence') return '#E8B16E';
+      if ($tone === 'processing') return '#8FCBC2';
+      return '#BFC7D4';
+    }};
+  background: ${({ $tone }) => {
+    if ($tone === 'absence') return '#FFF2E2';
+    if ($tone === 'processing') return '#E6F7F2';
+    return '#F3F5F8';
+  }};
+  color: ${({ $tone }) => {
+    if ($tone === 'absence') return '#C56A17';
+    if ($tone === 'processing') return '#3E8D80';
+    return '#586072';
+  }};
+
+  svg {
+    width: 14px;
+    height: 14px;
+  }
+`;

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -34,6 +34,7 @@ export const AppLayout = () => {
 
   const title = currentMatch?.handle?.title;
   const tabsConfig = currentMatch?.handle?.tabs;
+  const hasHeader = Boolean(title);
 
   const firstTab = tabsConfig?.items[0]?.id ?? '';
   const [activeTab, setActiveTab] = useState<string>(firstTab);
@@ -49,7 +50,7 @@ export const AppLayout = () => {
     <Shell>
       <Sidebar />
       <Main>
-        {title && <Header title={title} actions={headerActions} />}
+        {hasHeader ? <Header title={title!} actions={headerActions} /> : null}
 
         {tabsConfig?.items.length ? (
           <Tabs
@@ -61,7 +62,7 @@ export const AppLayout = () => {
           />
         ) : null}
 
-        <Content>
+        <Content $hasHeader={hasHeader}>
           <Outlet
             context={{
               setHeaderActions,
@@ -87,8 +88,8 @@ const Main = styled.div`
   margin-left: ${SIDEBAR_WIDTH.closed}px;
 `;
 
-const Content = styled.main`
-  height: calc(100vh - ${HEADER_HEIGHT}px);
+const Content = styled.main<{ $hasHeader: boolean }>`
+  height: ${({ $hasHeader }) => ($hasHeader ? `calc(100vh - ${HEADER_HEIGHT}px)` : '100vh')};
   min-height: 0;
-  margin-top: ${HEADER_HEIGHT}px;
+  margin-top: ${({ $hasHeader }) => ($hasHeader ? `${HEADER_HEIGHT}px` : 0)};
 `;

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -1,5 +1,5 @@
 import styled from '@emotion/styled';
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useCallback, useState } from 'react';
 import { Outlet, useLocation, useMatches } from 'react-router-dom';
 import { useDashboardTabs } from '@/features/admin/dashboard/hooks/useDashboardTabs';
 import { Sidebar } from '@/components/common/Sidebar';
@@ -27,9 +27,18 @@ export const AppLayout = () => {
 
   const headerActions =
     headerActionState.pathname === pathname ? headerActionState.actions : undefined;
-  const setHeaderActions = (actions?: ReactNode) => {
-    setHeaderActionState({ pathname, actions });
-  };
+  const setHeaderActions = useCallback(
+    (actions?: ReactNode) => {
+      setHeaderActionState(prev => {
+        if (prev.pathname === pathname && prev.actions === actions) {
+          return prev;
+        }
+
+        return { pathname, actions };
+      });
+    },
+    [pathname]
+  );
   const currentMatch = [...matches].reverse().find(match => match.handle);
 
   const title = currentMatch?.handle?.title;

--- a/src/pages/auth/TeacherSignUpPage.tsx
+++ b/src/pages/auth/TeacherSignUpPage.tsx
@@ -1,5 +1,6 @@
 ﻿import styled from '@emotion/styled';
 import { InlineButton } from '@/components/common/InlineButton';
+import { TextField } from '@/components/common/TextField';
 import { IcCheck, IcCopy, IcInfo, IcSparkles } from '@/icons';
 import { useTeacherSignUpForm } from '@/features/auth/hooks/useTeacherSignUpForm';
 
@@ -44,81 +45,56 @@ export const TeacherSignUpPage = () => {
 
             <SignUpForm onSubmit={handleSubmit}>
               <InputGroup>
-                <Label
-                  htmlFor="teacherName"
-                  hasError={Boolean(showFieldErrors && fieldErrors.teacherName)}
-                >
-                  이름 <RequiredMark>*</RequiredMark>
-                </Label>
-                <Input
+                <FieldInput
                   id="teacherName"
                   name="teacherName"
+                  label="이름"
+                  isRequired
                   value={teacherName}
                   onChange={event => setTeacherName(event.target.value)}
                   placeholder="홍길동"
-                  hasError={Boolean(showFieldErrors && fieldErrors.teacherName)}
+                  errorMessage={showFieldErrors ? fieldErrors.teacherName : undefined}
                 />
-                {showFieldErrors && fieldErrors.teacherName ? (
-                  <FieldErrorText>{fieldErrors.teacherName}</FieldErrorText>
-                ) : null}
               </InputGroup>
 
               <InputGroup>
-                <Label
-                  htmlFor="schoolName"
-                  hasError={Boolean(showFieldErrors && fieldErrors.schoolName)}
-                >
-                  학교명 <RequiredMark>*</RequiredMark>
-                </Label>
-                <Input
+                <FieldInput
                   id="schoolName"
                   name="schoolName"
+                  label="학교명"
+                  isRequired
                   value={schoolName}
                   onChange={event => setSchoolName(event.target.value)}
                   placeholder="한국초등학교"
-                  hasError={Boolean(showFieldErrors && fieldErrors.schoolName)}
+                  errorMessage={showFieldErrors ? fieldErrors.schoolName : undefined}
                 />
-                {showFieldErrors && fieldErrors.schoolName ? (
-                  <FieldErrorText>{fieldErrors.schoolName}</FieldErrorText>
-                ) : null}
               </InputGroup>
 
               <InlineTwoColumn>
                 <InputGroup>
-                  <Label htmlFor="grade" hasError={Boolean(showFieldErrors && fieldErrors.grade)}>
-                    학년 <RequiredMark>*</RequiredMark>
-                  </Label>
-                  <Input
+                  <FieldInput
                     id="grade"
                     name="grade"
+                    label="학년"
+                    isRequired
                     value={grade}
                     onChange={event => setGrade(event.target.value)}
                     placeholder="3"
-                    hasError={Boolean(showFieldErrors && fieldErrors.grade)}
+                    errorMessage={showFieldErrors ? fieldErrors.grade : undefined}
                   />
-                  {showFieldErrors && fieldErrors.grade ? (
-                    <FieldErrorText>{fieldErrors.grade}</FieldErrorText>
-                  ) : null}
                 </InputGroup>
 
                 <InputGroup>
-                  <Label
-                    htmlFor="classNumber"
-                    hasError={Boolean(showFieldErrors && fieldErrors.classNumber)}
-                  >
-                    반 <RequiredMark>*</RequiredMark>
-                  </Label>
-                  <Input
+                  <FieldInput
                     id="classNumber"
                     name="classNumber"
+                    label="반"
+                    isRequired
                     value={classNumber}
                     onChange={event => setClassNumber(event.target.value)}
                     placeholder="2"
-                    hasError={Boolean(showFieldErrors && fieldErrors.classNumber)}
+                    errorMessage={showFieldErrors ? fieldErrors.classNumber : undefined}
                   />
-                  {showFieldErrors && fieldErrors.classNumber ? (
-                    <FieldErrorText>{fieldErrors.classNumber}</FieldErrorText>
-                  ) : null}
                 </InputGroup>
               </InlineTwoColumn>
 
@@ -230,7 +206,7 @@ export const TeacherSignUpPage = () => {
 
 const PageContainer = styled.div`
   min-height: 100vh;
-  background: #e5e5e5;
+  background: ${({ theme }) => theme.colors.background.bg5};
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -242,8 +218,8 @@ const Card = styled.section`
   width: 100%;
   max-width: 560px;
   border-radius: 20px;
-  background: #f4f4f4;
-  box-shadow: 0 12px 22px rgba(0, 0, 0, 0.14);
+  background: ${({ theme }) => theme.colors.background.bg3};
+  box-shadow: ${({ theme }) => theme.colors.shadow.modal};
   padding: 28px 30px;
 
   @media (max-width: 640px) {
@@ -256,7 +232,7 @@ const ProgressTrack = styled.div`
   width: 100%;
   height: 3px;
   border-radius: 999px;
-  background: #bdbdbd;
+  background: ${({ theme }) => theme.colors.neutral.neutral400};
   overflow: hidden;
 `;
 
@@ -290,7 +266,7 @@ const SignUpForm = styled.form`
 const InputGroup = styled.div`
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 0;
 `;
 
 const InlineTwoColumn = styled.div`
@@ -299,40 +275,8 @@ const InlineTwoColumn = styled.div`
   gap: 10px;
 `;
 
-const Label = styled.label<{ hasError?: boolean }>`
-  ${({ theme }) => theme.fonts.labelS};
-  color: ${({ hasError, theme }) =>
-    hasError ? theme.colors.semantic.error : theme.colors.text.text1};
-`;
-
-const RequiredMark = styled.span`
-  color: ${({ theme }) => theme.colors.semantic.error};
-`;
-
-const Input = styled.input<{ hasError?: boolean }>`
-  ${({ theme }) => theme.fonts.body2};
-  border: 1px solid ${({ hasError }) => (hasError ? '#ff5b66' : '#c6c6c6')};
-  border-radius: 10px;
-  background: #f4f4f4;
-  padding: 11px 12px;
-  color: ${({ theme }) => theme.colors.text.text1};
-
-  &::placeholder {
-    color: #9a9a9a;
-  }
-
-  &:focus {
-    outline: none;
-    border-color: ${({ hasError, theme }) => (hasError ? '#ff5b66' : theme.colors.brand.primary)};
-    box-shadow: ${({ hasError }) =>
-      hasError ? '0 0 0 2px rgba(255, 44, 61, 0.14)' : '0 0 0 2px rgba(85, 181, 166, 0.16)'};
-  }
-`;
-
-const FieldErrorText = styled.p`
-  ${({ theme }) => theme.fonts.caption};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
+const FieldInput = styled(TextField)`
+  width: 100%;
 `;
 
 const ErrorBox = styled.div`
@@ -340,8 +284,8 @@ const ErrorBox = styled.div`
   gap: 10px;
   align-items: center;
   border-radius: 16px;
-  border: 1px solid #ff5b66;
-  background: #ffe9ec;
+  border: 1px solid ${({ theme }) => theme.colors.semantic.error};
+  background: ${({ theme }) => theme.colors.semantic.errorSoft};
   padding: 12px 14px;
 `;
 
@@ -394,8 +338,8 @@ const SuccessIconContainer = styled.span`
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  background: #e8f3f1;
-  color: #5b8f8a;
+  background: ${({ theme }) => theme.colors.background.bg4};
+  color: ${({ theme }) => theme.colors.brand.dark};
 
   svg {
     width: 30px;
@@ -421,8 +365,8 @@ const ClassCodeCard = styled.div`
   width: 100%;
   margin-top: 18px;
   border-radius: 14px;
-  border: 1px solid #c9e6e1;
-  background: #ddebe8;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 18px 14px;
   display: flex;
   flex-direction: column;
@@ -433,7 +377,7 @@ const ClassCodeCard = styled.div`
 const ClassLabel = styled.p`
   ${({ theme }) => theme.fonts.caption};
   margin: 0;
-  color: #4a7b76;
+  color: ${({ theme }) => theme.colors.brand.dark};
 `;
 
 const ClassCode = styled.p`
@@ -455,6 +399,6 @@ const CopyButton = styled(InlineButton)`
 
 const FooterText = styled.p`
   ${({ theme }) => theme.fonts.body3};
-  color: #919191;
+  color: ${({ theme }) => theme.colors.neutral.neutral500};
   margin: 18px 0 0;
 `;

--- a/src/pages/teacher/reports/TeacherReportsPage.tsx
+++ b/src/pages/teacher/reports/TeacherReportsPage.tsx
@@ -40,19 +40,19 @@ export const TeacherReportsPage = () => {
   return (
     <ReportsPageContainer>
       <ReportListSection>
-        {isLoading ? <StatusText>목록을 불러오는 중이에요...</StatusText> : null}
+        {isLoading ? <StatusText>목록??불러?�는 중이?�요...</StatusText> : null}
         {hasListError ? (
           <ErrorPane>
             <ErrorIconWrap>
               <IcError />
             </ErrorIconWrap>
-            <ErrorTitle>대화 목록을 불러올 수 없어요.</ErrorTitle>
+            <ErrorTitle>?�??목록??불러?????�어??</ErrorTitle>
             <ErrorDescription>{listErrorDisplayMessage}</ErrorDescription>
             <InlineButton
               variant="primary"
               size="L"
               icon={IcRefresh}
-              label="다시 시도"
+              label="?�시 ?�도"
               onClick={() => void fetchReportRooms()}
             />
           </ErrorPane>
@@ -63,11 +63,11 @@ export const TeacherReportsPage = () => {
             <EmptyIconWrap>
               <IcChat />
             </EmptyIconWrap>
-            <EmptyTitle>아직 데이터가 없어요.</EmptyTitle>
+            <EmptyTitle>?�직 ?�이?��? ?�어??</EmptyTitle>
             <EmptyDescription>
-              학부모와의 대화가 시작되면 이곳에서 대화를 선택해
+              ?��?모�????�?��? ?�작?�면 ?�곳?�서 ?�?��? ?�택??
               <br />
-              리포트를 생성할 수 있어요.
+              리포?��? ?�성?????�어??
             </EmptyDescription>
           </EmptyPane>
         ) : null}
@@ -86,7 +86,7 @@ export const TeacherReportsPage = () => {
                     <StudentName>{item.studentName || '-'}</StudentName>
                   </ReportTitleWrap>
                   <LastMessageDate>
-                    마지막 메시지: {formatDateOnly(item.lastMessageAt)}
+                    마�?�?메시지: {formatDateOnly(item.lastMessageAt)}
                   </LastMessageDate>
                 </ReportItemTopRow>
 
@@ -112,7 +112,7 @@ export const TeacherReportsPage = () => {
               variant="primary"
               size="L"
               icon={IcFile}
-              label={isGeneratingPdf ? '생성 중...' : 'PDF 생성하기'}
+              label={isGeneratingPdf ? '?�성 �?..' : 'PDF ?�성?�기'}
               disabled={
                 !selectedReport ||
                 hasNoData ||
@@ -131,25 +131,25 @@ export const TeacherReportsPage = () => {
               <EmptyIconWrap>
                 <IcFile />
               </EmptyIconWrap>
-              <EmptyTitle>미리볼 대화를 선택해주세요</EmptyTitle>
+              <EmptyTitle>미리�??�?��? ?�택?�주?�요</EmptyTitle>
               <EmptyDescription>
-                왼쪽 목록에서 대화를 선택하면 대화 리포트를 확인할 수 있어요.
+                ?�쪽 목록?�서 ?�?��? ?�택?�면 ?�??리포?��? ?�인?????�어??
               </EmptyDescription>
             </PreviewEmptyPane>
           ) : isPreviewLoading ? (
-            <StatusText>미리보기를 불러오는 중이에요...</StatusText>
+            <StatusText>미리보기�?불러?�는 중이?�요...</StatusText>
           ) : isPreviewLoadError ? (
             <ErrorPane>
               <ErrorIconWrap>
                 <IcError />
               </ErrorIconWrap>
-              <ErrorTitle>미리보기를 불러올 수 없어요.</ErrorTitle>
-              <ErrorDescription>잠시 후 다시 시도해 주세요.</ErrorDescription>
+              <ErrorTitle>미리보기�?불러?????�어??</ErrorTitle>
+              <ErrorDescription>?�시 ???�시 ?�도??주세??</ErrorDescription>
               <InlineButton
                 variant="primary"
                 size="L"
                 icon={IcRefresh}
-                label="다시 시도"
+                label="?�시 ?�도"
                 onClick={retryPreviewMessages}
               />
             </ErrorPane>
@@ -158,8 +158,8 @@ export const TeacherReportsPage = () => {
               <EmptyIconWrap>
                 <IcFile />
               </EmptyIconWrap>
-              <EmptyTitle>미리보기 데이터가 없어요.</EmptyTitle>
-              <EmptyDescription>선택한 채팅방에 표시할 메시지가 없어요.</EmptyDescription>
+              <EmptyTitle>미리보기 ?�이?��? ?�어??</EmptyTitle>
+              <EmptyDescription>?�택??채팅방에 ?�시??메시지가 ?�어??</EmptyDescription>
             </PreviewEmptyPane>
           ) : (
             <>
@@ -197,7 +197,7 @@ export const TeacherReportsPage = () => {
                   <InlineButton
                     variant="ghost"
                     size="M"
-                    label={isPreviewLoadingMore ? '불러오는 중...' : '더 보기'}
+                    label={isPreviewLoadingMore ? '불러?�는 �?..' : '??보기'}
                     disabled={isPreviewLoadingMore}
                     onClick={handleLoadMorePreview}
                   />
@@ -215,8 +215,8 @@ export const TeacherReportsPage = () => {
               <IcFile />
             </ModalIconWrap>
 
-            <ModalTitle>리포트 생성 완료</ModalTitle>
-            <ModalDescription>PDF 파일이 준비되었습니다.</ModalDescription>
+            <ModalTitle>리포???�성 ?�료</ModalTitle>
+            <ModalDescription>PDF ?�일??준비되?�습?�다.</ModalDescription>
 
             <FileInfoCard>
               <FileInfoLabel>파일명</FileInfoLabel>
@@ -229,8 +229,8 @@ export const TeacherReportsPage = () => {
                   <IcError />
                 </ModalErrorIcon>
                 <ModalErrorTextWrap>
-                  <ModalErrorTitle>PDF 다운로드에 실패했어요.</ModalErrorTitle>
-                  <ModalErrorDescription>잠시 후 다시 시도해 주세요.</ModalErrorDescription>
+                  <ModalErrorTitle>PDF ?�운로드???�패?�어??</ModalErrorTitle>
+                  <ModalErrorDescription>?�시 ???�시 ?�도??주세??</ModalErrorDescription>
                 </ModalErrorTextWrap>
               </ModalErrorBox>
             ) : null}
@@ -239,7 +239,7 @@ export const TeacherReportsPage = () => {
               <InlineButton
                 variant="ghost"
                 size="L"
-                label="닫기"
+                label="?�기"
                 width="100%"
                 onClick={handleCloseReportCompleteModal}
               />
@@ -247,7 +247,7 @@ export const TeacherReportsPage = () => {
                 variant="primary"
                 size="L"
                 icon={IcDownload}
-                label={isDownloadingPdf ? '다운로드 중...' : '다운로드'}
+                label={isDownloadingPdf ? '?�운로드 �?..' : '?�운로드'}
                 width="100%"
                 disabled={isDownloadingPdf}
                 onClick={() => void handleDownloadGeneratedPdf()}
@@ -405,7 +405,7 @@ const PreviewTitle = styled.h3`
 const PreviewBody = styled.div`
   min-height: 620px;
   border-radius: 0 0 24px 24px;
-  background: ${({ theme }) => theme.colors.reports.previewBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 22px;
   display: flex;
   flex-direction: column;
@@ -429,7 +429,7 @@ const SenderAvatar = styled.div`
   width: 44px;
   height: 44px;
   border-radius: 999px;
-  background: ${({ theme }) => theme.colors.reports.senderAvatarBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   color: ${({ theme }) => theme.colors.brand.dark};
   display: inline-flex;
   align-items: center;
@@ -557,7 +557,7 @@ const ModalOverlay = styled.div`
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: ${({ theme }) => theme.colors.overlay.dim1};
+  background: ${({ theme }) => theme.colors.overlay.dim};
   display: flex;
   align-items: center;
   justify-content: center;
@@ -626,9 +626,9 @@ const ModalActionRow = styled.div`
 
 const ModalErrorBox = styled.div`
   margin-top: 14px;
-  border: 1px solid ${({ theme }) => theme.colors.reports.modalErrorBorder};
+  border: 1px solid ${({ theme }) => theme.colors.semantic.error};
   border-radius: 18px;
-  background: ${({ theme }) => theme.colors.reports.modalErrorBackground};
+  background: ${({ theme }) => theme.colors.semantic.errorSoft};
   padding: 14px 16px;
   display: flex;
   align-items: center;
@@ -656,11 +656,11 @@ const ModalErrorTextWrap = styled.div`
 const ModalErrorTitle = styled.p`
   ${({ theme }) => theme.fonts.labelXS};
   margin: 0;
-  color: ${({ theme }) => theme.colors.reports.modalErrorText};
+  color: ${({ theme }) => theme.colors.semantic.error};
 `;
 
 const ModalErrorDescription = styled.p`
   ${({ theme }) => theme.fonts.body3};
   margin: 0;
-  color: ${({ theme }) => theme.colors.reports.modalErrorText};
+  color: ${({ theme }) => theme.colors.semantic.error};
 `;

--- a/src/pages/teacher/reports/TeacherReportsPage.tsx
+++ b/src/pages/teacher/reports/TeacherReportsPage.tsx
@@ -40,19 +40,19 @@ export const TeacherReportsPage = () => {
   return (
     <ReportsPageContainer>
       <ReportListSection>
-        {isLoading ? <StatusText>목록??불러?�는 중이?�요...</StatusText> : null}
+        {isLoading ? <StatusText>목록을 불러오는 중이에요...</StatusText> : null}
         {hasListError ? (
           <ErrorPane>
             <ErrorIconWrap>
               <IcError />
             </ErrorIconWrap>
-            <ErrorTitle>?�??목록??불러?????�어??</ErrorTitle>
+            <ErrorTitle>채팅방 목록을 불러오지 못했어요</ErrorTitle>
             <ErrorDescription>{listErrorDisplayMessage}</ErrorDescription>
             <InlineButton
               variant="primary"
               size="L"
               icon={IcRefresh}
-              label="?�시 ?�도"
+              label="다시 시도"
               onClick={() => void fetchReportRooms()}
             />
           </ErrorPane>
@@ -63,11 +63,11 @@ export const TeacherReportsPage = () => {
             <EmptyIconWrap>
               <IcChat />
             </EmptyIconWrap>
-            <EmptyTitle>?�직 ?�이?��? ?�어??</EmptyTitle>
+            <EmptyTitle>아직 데이터가 없어요</EmptyTitle>
             <EmptyDescription>
-              ?��?모�????�?��? ?�작?�면 ?�곳?�서 ?�?��? ?�택??
+              학부모님과의 대화가 시작되면 이곳에서 채팅방을 선택해
               <br />
-              리포?��? ?�성?????�어??
+              리포트를 생성할 수 있어요.
             </EmptyDescription>
           </EmptyPane>
         ) : null}
@@ -86,7 +86,7 @@ export const TeacherReportsPage = () => {
                     <StudentName>{item.studentName || '-'}</StudentName>
                   </ReportTitleWrap>
                   <LastMessageDate>
-                    마�?�?메시지: {formatDateOnly(item.lastMessageAt)}
+                    마지막 메시지: {formatDateOnly(item.lastMessageAt)}
                   </LastMessageDate>
                 </ReportItemTopRow>
 
@@ -112,7 +112,7 @@ export const TeacherReportsPage = () => {
               variant="primary"
               size="L"
               icon={IcFile}
-              label={isGeneratingPdf ? '?�성 �?..' : 'PDF ?�성?�기'}
+              label={isGeneratingPdf ? '생성 중...' : 'PDF 생성하기'}
               disabled={
                 !selectedReport ||
                 hasNoData ||
@@ -131,25 +131,25 @@ export const TeacherReportsPage = () => {
               <EmptyIconWrap>
                 <IcFile />
               </EmptyIconWrap>
-              <EmptyTitle>미리�??�?��? ?�택?�주?�요</EmptyTitle>
+              <EmptyTitle>미리보기 대상을 선택해주세요</EmptyTitle>
               <EmptyDescription>
-                ?�쪽 목록?�서 ?�?��? ?�택?�면 ?�??리포?��? ?�인?????�어??
+                왼쪽 목록에서 채팅방을 선택하면 해당 리포트를 확인할 수 있어요.
               </EmptyDescription>
             </PreviewEmptyPane>
           ) : isPreviewLoading ? (
-            <StatusText>미리보기�?불러?�는 중이?�요...</StatusText>
+            <StatusText>미리보기를 불러오는 중이에요...</StatusText>
           ) : isPreviewLoadError ? (
             <ErrorPane>
               <ErrorIconWrap>
                 <IcError />
               </ErrorIconWrap>
-              <ErrorTitle>미리보기�?불러?????�어??</ErrorTitle>
-              <ErrorDescription>?�시 ???�시 ?�도??주세??</ErrorDescription>
+              <ErrorTitle>미리보기를 불러오지 못했어요</ErrorTitle>
+              <ErrorDescription>잠시 후 다시 시도해 주세요</ErrorDescription>
               <InlineButton
                 variant="primary"
                 size="L"
                 icon={IcRefresh}
-                label="?�시 ?�도"
+                label="다시 시도"
                 onClick={retryPreviewMessages}
               />
             </ErrorPane>
@@ -158,8 +158,8 @@ export const TeacherReportsPage = () => {
               <EmptyIconWrap>
                 <IcFile />
               </EmptyIconWrap>
-              <EmptyTitle>미리보기 ?�이?��? ?�어??</EmptyTitle>
-              <EmptyDescription>?�택??채팅방에 ?�시??메시지가 ?�어??</EmptyDescription>
+              <EmptyTitle>미리보기 데이터가 없어요</EmptyTitle>
+              <EmptyDescription>선택한 채팅방에 표시할 메시지가 없어요</EmptyDescription>
             </PreviewEmptyPane>
           ) : (
             <>
@@ -197,7 +197,7 @@ export const TeacherReportsPage = () => {
                   <InlineButton
                     variant="ghost"
                     size="M"
-                    label={isPreviewLoadingMore ? '불러?�는 �?..' : '??보기'}
+                    label={isPreviewLoadingMore ? '불러오는 중...' : '더 보기'}
                     disabled={isPreviewLoadingMore}
                     onClick={handleLoadMorePreview}
                   />
@@ -215,8 +215,8 @@ export const TeacherReportsPage = () => {
               <IcFile />
             </ModalIconWrap>
 
-            <ModalTitle>리포???�성 ?�료</ModalTitle>
-            <ModalDescription>PDF ?�일??준비되?�습?�다.</ModalDescription>
+            <ModalTitle>리포트 생성 완료</ModalTitle>
+            <ModalDescription>PDF 파일이 준비되었어요.</ModalDescription>
 
             <FileInfoCard>
               <FileInfoLabel>파일명</FileInfoLabel>
@@ -229,8 +229,8 @@ export const TeacherReportsPage = () => {
                   <IcError />
                 </ModalErrorIcon>
                 <ModalErrorTextWrap>
-                  <ModalErrorTitle>PDF ?�운로드???�패?�어??</ModalErrorTitle>
-                  <ModalErrorDescription>?�시 ???�시 ?�도??주세??</ModalErrorDescription>
+                  <ModalErrorTitle>PDF 다운로드에 실패했어요</ModalErrorTitle>
+                  <ModalErrorDescription>잠시 후 다시 시도해 주세요</ModalErrorDescription>
                 </ModalErrorTextWrap>
               </ModalErrorBox>
             ) : null}
@@ -239,7 +239,7 @@ export const TeacherReportsPage = () => {
               <InlineButton
                 variant="ghost"
                 size="L"
-                label="?�기"
+                label="닫기"
                 width="100%"
                 onClick={handleCloseReportCompleteModal}
               />
@@ -247,7 +247,7 @@ export const TeacherReportsPage = () => {
                 variant="primary"
                 size="L"
                 icon={IcDownload}
-                label={isDownloadingPdf ? '?�운로드 �?..' : '?�운로드'}
+                label={isDownloadingPdf ? '다운로드 중...' : '다운로드'}
                 width="100%"
                 disabled={isDownloadingPdf}
                 onClick={() => void handleDownloadGeneratedPdf()}
@@ -372,6 +372,7 @@ const IntentBadge = styled.span<{ intent: IntentType }>`
 const PreviewSection = styled.section`
   width: 48%;
   min-width: 0;
+  min-height: 0;
   padding: 34px 26px;
 
   @media (max-width: 1200px) {
@@ -403,13 +404,16 @@ const PreviewTitle = styled.h3`
 `;
 
 const PreviewBody = styled.div`
-  min-height: 620px;
+  height: min(620px, calc(100vh - 220px));
+  min-height: 420px;
   border-radius: 0 0 24px 24px;
   background: ${({ theme }) => theme.colors.background.bg4};
   padding: 22px;
   display: flex;
   flex-direction: column;
   gap: 16px;
+  overflow-y: auto;
+  overflow-x: hidden;
 `;
 
 const MessageBlock = styled.div<{ align?: 'left' | 'right' }>`

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -3,8 +3,6 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AxiosError } from 'axios';
 import { useOutletContext } from 'react-router-dom';
 import { InlineButton } from '@/components/common/InlineButton';
-import { TextField } from '@/components/common/TextField';
-import { ToggleSwitch } from '@/components/common/ToggleSwitch';
 import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
 import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
 import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
@@ -25,13 +23,13 @@ const EMPTY_TIME = '';
 const TIME_PLACEHOLDER = '00:00';
 
 const DAY_INFO: { key: WorkdayKey; dayOfWeek: number; label: string }[] = [
-  { key: 'mon', dayOfWeek: 1, label: '��' },
-  { key: 'tue', dayOfWeek: 2, label: 'ȭ' },
-  { key: 'wed', dayOfWeek: 3, label: '��' },
-  { key: 'thu', dayOfWeek: 4, label: '��' },
-  { key: 'fri', dayOfWeek: 5, label: '��' },
-  { key: 'sat', dayOfWeek: 6, label: '��' },
-  { key: 'sun', dayOfWeek: 7, label: '��' },
+  { key: 'mon', dayOfWeek: 1, label: '월' },
+  { key: 'tue', dayOfWeek: 2, label: '화' },
+  { key: 'wed', dayOfWeek: 3, label: '수' },
+  { key: 'thu', dayOfWeek: 4, label: '목' },
+  { key: 'fri', dayOfWeek: 5, label: '금' },
+  { key: 'sat', dayOfWeek: 6, label: '토' },
+  { key: 'sun', dayOfWeek: 7, label: '일' },
 ];
 
 const toDisplayTime = (value: string | null | undefined) => {
@@ -158,7 +156,7 @@ export const TeacherSettingsPage = () => {
         }
 
         const axiosError = error as AxiosError<{ message?: string }>;
-        setErrorMessage(axiosError.response?.data?.message || '���� ������ �ҷ����� ���߾��.');
+        setErrorMessage(axiosError.response?.data?.message || '설정 정보를 불러오지 못했어요.');
       } finally {
         if (isMounted) {
           setIsLoading(false);
@@ -197,13 +195,13 @@ export const TeacherSettingsPage = () => {
       return '-';
     }
 
-    return `${gradeInput}�г� ${classInput}`;
+    return `${gradeInput}학년 ${classInput}`;
   }, [classInput, gradeInput]);
 
   const handleOpenClassChangeModal = () => {
     setSchoolNameInput(setting?.schoolName ?? '');
     setGradeInput(setting?.grade != null ? String(setting.grade) : '');
-    setClassInput(setting?.classNumber != null ? `${setting.classNumber}��` : '');
+    setClassInput(setting?.classNumber != null ? `${setting.classNumber}반` : '');
     setIsClassChangeModalOpen(true);
   };
 
@@ -238,7 +236,7 @@ export const TeacherSettingsPage = () => {
     const classNumber = extractClassNumber(classInput.trim());
 
     if (!classNumber) {
-      setClassChangeErrorTitle('�� ������ Ȯ�����ּ���.');
+      setClassChangeErrorTitle('반 정보를 확인해주세요.');
       return;
     }
 
@@ -252,7 +250,7 @@ export const TeacherSettingsPage = () => {
       });
 
       if (!response.success) {
-        setClassChangeErrorTitle(response.message || '�б� ���濡 �����߾��.');
+        setClassChangeErrorTitle(response.message || '학급 변경에 실패했어요.');
         return;
       }
 
@@ -275,7 +273,7 @@ export const TeacherSettingsPage = () => {
       setIsClassChangeSuccessModalOpen(true);
     } catch (error) {
       const axiosError = error as AxiosError<{ message?: string }>;
-      setClassChangeErrorTitle(axiosError.response?.data?.message || '�б� ���濡 �����߾��.');
+      setClassChangeErrorTitle(axiosError.response?.data?.message || '학급 변경에 실패했어요.');
     } finally {
       setIsClassChangeSubmitting(false);
     }
@@ -285,20 +283,20 @@ export const TeacherSettingsPage = () => {
     const classCode = rawClassCode?.trim();
 
     if (!classCode) {
-      showToast('������ �б��ڵ尡 �����.', 'error');
+      showToast('복사할 학급코드가 없어요.', 'error');
       return;
     }
 
     if (!navigator.clipboard) {
-      showToast('���� ������������ ���縦 �������� �ʾƿ�.', 'error');
+      showToast('현재 브라우저에서는 복사를 지원하지 않아요.', 'error');
       return;
     }
 
     try {
       await navigator.clipboard.writeText(classCode);
-      showToast('�б��ڵ带 �����߾��.', 'success');
+      showToast('학급코드를 복사했어요.', 'success');
     } catch {
-      showToast('�б��ڵ� ���翡 �����߾��.', 'error');
+      showToast('학급코드 복사에 실패했어요.', 'error');
     }
   };
 
@@ -371,7 +369,7 @@ export const TeacherSettingsPage = () => {
     }
 
     setWorkdays(initialWorkdays);
-    showToast('�ٹ��ð� �Է°��� �ǵ��Ⱦ��.', 'success');
+    showToast('근무시간 입력값을 되돌렸어요.', 'success');
   }, [hasWorkHoursChanges, initialWorkdays, isLoading, showToast]);
 
   const handleSaveWorkHours = useCallback(async () => {
@@ -381,7 +379,7 @@ export const TeacherSettingsPage = () => {
 
     const enabledWorkdays = workdays.filter(day => day.enabled);
     if (enabledWorkdays.length === 0) {
-      showToast('�ٹ� ������ 1�� �̻� Ȱ��ȭ���ּ���.', 'error');
+      showToast('근무 요일을 1개 이상 활성화해주세요.', 'error');
       return;
     }
 
@@ -390,7 +388,7 @@ export const TeacherSettingsPage = () => {
     );
 
     if (invalidWorkday) {
-      showToast(`${invalidWorkday.label}���� �ð��� HH:mm �������� �Է����ּ���.`, 'error');
+      showToast(`${invalidWorkday.label}요일 시간을 HH:mm 형식으로 입력해주세요.`, 'error');
       return;
     }
 
@@ -398,7 +396,7 @@ export const TeacherSettingsPage = () => {
       day => toMinutes(day.start) >= toMinutes(day.end)
     );
     if (invalidOrderWorkday) {
-      showToast(`${invalidOrderWorkday.label}���� ���� �ð��� ���� �ð����� �ʾ�� �ؿ�.`, 'error');
+      showToast(`${invalidOrderWorkday.label}요일 종료 시간은 시작 시간보다 늦어야 해요.`, 'error');
       return;
     }
 
@@ -420,8 +418,8 @@ export const TeacherSettingsPage = () => {
         const failMessage = response.message?.trim()
           ? response.message
           : response.code
-            ? `�ٹ��ð� ���忡 �����߾��. (code: ${response.code})`
-            : '�ٹ��ð� ���忡 �����߾��.';
+            ? `근무시간 저장에 실패했어요. (code: ${response.code})`
+            : '근무시간 저장에 실패했어요.';
         showToast(failMessage, 'error');
         return;
       }
@@ -442,7 +440,7 @@ export const TeacherSettingsPage = () => {
       });
 
       setInitialWorkdays(workdays);
-      showToast('�ٹ��ð��� ����Ǿ����.', 'success');
+      showToast('근무시간이 저장되었어요.', 'success');
     } catch (error) {
       const axiosError = error as AxiosError<{
         message?: string;
@@ -454,7 +452,7 @@ export const TeacherSettingsPage = () => {
         axiosError.response?.data?.error?.message ??
         axiosError.message;
       showToast(
-        `${serverMessage || '�ٹ��ð� ���忡 �����߾��.'}${status ? ` (HTTP ${status})` : ''}`,
+        `${serverMessage || '근무시간 저장에 실패했어요.'}${status ? ` (HTTP ${status})` : ''}`,
         'error'
       );
     } finally {
@@ -474,7 +472,7 @@ export const TeacherSettingsPage = () => {
     <PageContainer>
       <ContentArea>
         <CardSection>
-          <SectionTitle>������ ����</SectionTitle>
+          <SectionTitle>프로필 정보</SectionTitle>
           <ProfileRow>
             <AvatarCircle>{profileInitial}</AvatarCircle>
             <ProfileName>{profileName}</ProfileName>
@@ -483,19 +481,19 @@ export const TeacherSettingsPage = () => {
 
         <CardSection>
           <SectionHeader>
-            <SectionTitle>�ٹ��ð� ����</SectionTitle>
+            <SectionTitle>근무시간 설정</SectionTitle>
             <SectionActionGroup>
               <InlineButton
                 variant="ghost"
                 size="L"
-                label="���"
+                label="취소"
                 disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
                 onClick={handleResetWorkHours}
               />
               <InlineButton
                 variant="primary"
                 size="L"
-                label={isSavingWorkHours ? '���� ��...' : '������� ����'}
+                label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
                 disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
                 onClick={() => {
                   void handleSaveWorkHours();
@@ -504,22 +502,26 @@ export const TeacherSettingsPage = () => {
             </SectionActionGroup>
           </SectionHeader>
           <SectionDescription>
-            �кθ�Ե��� �޽����� ���� �� ������ �� �ִ� �ð��̿���. �ٹ� �ð� �ܿ��� Ȯ���� �ʾ��� �� �ִٴ� �ȳ���
-            �ص����.
+            학부모님들이 메시지를 보낼 때 참고할 수 있는 시간이에요. 근무 시간 외에는 확인이 늦어질
+            수 있다는 안내를 해드려요.
           </SectionDescription>
 
-          {isLoading ? <StateText>���� ������ �ҷ����� ���̿���...</StateText> : null}
+          {isLoading ? <StateText>설정 정보를 불러오는 중이에요...</StateText> : null}
           {!isLoading && errorMessage ? <ErrorText>{errorMessage}</ErrorText> : null}
 
           {!isLoading && !errorMessage ? (
             <WorkdayList>
               {workdays.map(day => (
                 <WorkdayRow key={day.key}>
-                  <ToggleSwitch
-                    checked={day.enabled}
-                    ariaLabel={`${day.label} ���� �ٹ��ð� ���`}
-                    onToggle={() => handleToggleWorkday(day.key)}
-                  />
+                  <ToggleButton
+                    type="button"
+                    isEnabled={day.enabled}
+                    aria-pressed={day.enabled}
+                    aria-label={`${day.label}요일 근무시간 사용`}
+                    onClick={() => handleToggleWorkday(day.key)}
+                  >
+                    <ToggleThumb isEnabled={day.enabled} />
+                  </ToggleButton>
 
                   <DayLabel>{day.label}</DayLabel>
 
@@ -556,23 +558,23 @@ export const TeacherSettingsPage = () => {
 
         <CardSection>
           <SectionHeader>
-            <SectionTitle>�б� ����</SectionTitle>
+            <SectionTitle>학급 관리</SectionTitle>
             <InlineButton
               type="button"
               variant="primary"
               size="L"
-              label="�б� �����ϱ�"
+              label="학급 변경하기"
               onClick={handleOpenClassChangeModal}
             />
           </SectionHeader>
 
           <ClassInfoGrid>
-            <InfoLabel>�б���</InfoLabel>
+            <InfoLabel>학교명</InfoLabel>
             <InfoValue>{setting?.schoolName?.trim() ? setting.schoolName : '-'}</InfoValue>
-            <InfoLabel>�б�</InfoLabel>
+            <InfoLabel>학급</InfoLabel>
             <InfoValue>
               {setting?.grade != null && setting?.classNumber != null
-                ? `${setting.grade}�г� ${setting.classNumber}��`
+                ? `${setting.grade}학년 ${setting.classNumber}반`
                 : '-'}
             </InfoValue>
           </ClassInfoGrid>
@@ -580,40 +582,28 @@ export const TeacherSettingsPage = () => {
           <Divider />
 
           <ClassCodeWrap>
-            <InfoLabel>�б� �ڵ�</InfoLabel>
+            <InfoLabel>학급 코드</InfoLabel>
             <ClassCodeActions>
               <ClassCodeBadge>
                 {setting?.classCode?.trim() ? setting.classCode : '-'}
               </ClassCodeBadge>
-              <CodeCopyButton
-                type="button"
-                variant="ghost"
-                size="L"
-                icon={IcCopy}
-                label="�б��ڵ� �����ϱ�"
-                onClick={handleCopyClassCode}
-              />
+              <CodeCopyButton type="button" onClick={handleCopyClassCode}>
+                <IcCopy />
+                학급코드 복사하기
+              </CodeCopyButton>
             </ClassCodeActions>
           </ClassCodeWrap>
         </CardSection>
 
         <CardSection>
-          <SectionTitle>���� ����</SectionTitle>
+          <SectionTitle>계정 관리</SectionTitle>
           <AccountLinkList>
-            <AccountLinkButton
-              type="button"
-              variant="text"
-              size="L"
-              label="�α׾ƿ�"
-              onClick={handleLogout}
-            />
-            <DangerLinkButton
-              type="button"
-              variant="text"
-              size="L"
-              label="ȸ�� Ż��"
-              onClick={handleOpenWithdrawModal}
-            />
+            <AccountLinkButton type="button" onClick={handleLogout}>
+              로그아웃
+            </AccountLinkButton>
+            <DangerLinkButton type="button" onClick={handleOpenWithdrawModal}>
+              회원 탈퇴
+            </DangerLinkButton>
           </AccountLinkList>
         </CardSection>
       </ContentArea>
@@ -625,11 +615,11 @@ export const TeacherSettingsPage = () => {
               <IcInfo />
             </ConfirmIconWrap>
 
-            <ModalTitle>ȸ�� Ż���Ͻðھ��?</ModalTitle>
+            <ModalTitle>회원 탈퇴하시겠어요?</ModalTitle>
             <ModalDescription>
-              Ż���ϸ� ���� ������ �����Ǹ� ������ �� �����.
+              탈퇴하면 계정 정보가 삭제되며 복구할 수 없어요.
               <br />
-              ���� Ż���Ͻ÷��� �Ʒ� ��ư�� ���� �ּ���.
+              정말 탈퇴하시려면 아래 버튼을 눌러 주세요.
             </ModalDescription>
 
             {withdrawErrorMessage ? (
@@ -639,29 +629,24 @@ export const TeacherSettingsPage = () => {
                 </ConfirmErrorIcon>
                 <ConfirmErrorTextWrap>
                   <ConfirmErrorTitle>{withdrawErrorMessage}</ConfirmErrorTitle>
-                  <ConfirmErrorDescription>��� �� �ٽ� �õ��� �ּ���.</ConfirmErrorDescription>
+                  <ConfirmErrorDescription>잠시 후 다시 시도해 주세요.</ConfirmErrorDescription>
                 </ConfirmErrorTextWrap>
               </ConfirmErrorBox>
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton
-                type="button"
-                variant="ghost"
-                size="L"
-                label="���"
-                onClick={handleCloseWithdrawModal}
-              />
+              <ModalGhostButton type="button" onClick={handleCloseWithdrawModal}>
+                취소
+              </ModalGhostButton>
               <ModalPrimaryButton
                 type="button"
-                variant="primary"
-                size="L"
-                label={isWithdrawing ? 'Ż�� ��...' : 'ȸ�� Ż��'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
                 disabled={isWithdrawing}
-              />
+              >
+                {isWithdrawing ? '탈퇴 중...' : '회원 탈퇴'}
+              </ModalPrimaryButton>
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -674,20 +659,20 @@ export const TeacherSettingsPage = () => {
               <IcChange />
             </ModalIconWrap>
 
-            <ModalTitle>�б� ����</ModalTitle>
+            <ModalTitle>학급 변경</ModalTitle>
             <ModalDescription>
-              �� �б� ������ �Է����ּ���. ������ �Ϸ�Ǹ� ���ο� �б� �ڵ尡 �߱޵ſ�.
+              새 학급 정보를 입력해주세요. 변경이 완료되면 새로운 학급 코드가 발급돼요.
             </ModalDescription>
 
             <ModalForm>
               <FormGroup>
                 <FormLabel>
-                  �б��� <RequiredAsterisk>*</RequiredAsterisk>
+                  학교명 <RequiredAsterisk>*</RequiredAsterisk>
                 </FormLabel>
                 <FormInput
                   value={schoolNameInput}
                   onChange={event => setSchoolNameInput(event.target.value)}
-                  placeholder="�б����� �Է����ּ���."
+                  placeholder="학교명을 입력해주세요."
                   autoComplete="off"
                 />
               </FormGroup>
@@ -695,30 +680,30 @@ export const TeacherSettingsPage = () => {
               <FormRow>
                 <FormGroup>
                   <FormLabel>
-                    �г� <RequiredAsterisk>*</RequiredAsterisk>
+                    학년 <RequiredAsterisk>*</RequiredAsterisk>
                   </FormLabel>
                   <FormSelect
                     value={gradeInput}
                     onChange={event => setGradeInput(event.target.value)}
                   >
-                    <option value="">�г��� �������ּ���.</option>
-                    <option value="1">1�г�</option>
-                    <option value="2">2�г�</option>
-                    <option value="3">3�г�</option>
-                    <option value="4">4�г�</option>
-                    <option value="5">5�г�</option>
-                    <option value="6">6�г�</option>
+                    <option value="">학년을 선택해주세요.</option>
+                    <option value="1">1학년</option>
+                    <option value="2">2학년</option>
+                    <option value="3">3학년</option>
+                    <option value="4">4학년</option>
+                    <option value="5">5학년</option>
+                    <option value="6">6학년</option>
                   </FormSelect>
                 </FormGroup>
 
                 <FormGroup>
                   <FormLabel>
-                    �� <RequiredAsterisk>*</RequiredAsterisk>
+                    반 <RequiredAsterisk>*</RequiredAsterisk>
                   </FormLabel>
                   <FormInput
                     value={classInput}
                     onChange={event => setClassInput(event.target.value)}
-                    placeholder="2��"
+                    placeholder="2반"
                     autoComplete="off"
                   />
                 </FormGroup>
@@ -726,21 +711,16 @@ export const TeacherSettingsPage = () => {
             </ModalForm>
 
             <ModalButtonRow>
-              <ModalGhostButton
-                type="button"
-                variant="ghost"
-                size="L"
-                label="���"
-                onClick={handleCloseClassChangeModal}
-              />
+              <ModalGhostButton type="button" onClick={handleCloseClassChangeModal}>
+                취소
+              </ModalGhostButton>
               <ModalPrimaryButton
                 type="button"
-                variant="primary"
-                size="L"
-                label="�����ϱ�"
                 disabled={!isClassChangeEnabled}
                 onClick={handleOpenClassChangeConfirmModal}
-              />
+              >
+                변경하기
+              </ModalPrimaryButton>
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -753,18 +733,19 @@ export const TeacherSettingsPage = () => {
               <IcInfo />
             </ConfirmIconWrap>
 
-            <ModalTitle>�б��� �����ұ��?</ModalTitle>
+            <ModalTitle>학급을 변경할까요?</ModalTitle>
             <ModalDescription>
-              �б��� �����ϸ� ���ο� �б� �ڵ尡 �߱޵ſ�. ���� �б� �ڵ�� �� �̻� ����� �� �����.
+              학급을 변경하면 새로운 학급 코드가 발급돼요. 기존 학급 코드는 더 이상 사용할 수
+              없어요.
             </ModalDescription>
 
             <ConfirmSummaryBox>
               <ConfirmSummaryRow>
-                <ConfirmSummaryLabel>�б���</ConfirmSummaryLabel>
+                <ConfirmSummaryLabel>학교명</ConfirmSummaryLabel>
                 <ConfirmSummaryValue>{schoolNameInput || '-'}</ConfirmSummaryValue>
               </ConfirmSummaryRow>
               <ConfirmSummaryRow>
-                <ConfirmSummaryLabel>�б�</ConfirmSummaryLabel>
+                <ConfirmSummaryLabel>학급</ConfirmSummaryLabel>
                 <ConfirmSummaryValue>{classSummaryText}</ConfirmSummaryValue>
               </ConfirmSummaryRow>
             </ConfirmSummaryBox>
@@ -776,27 +757,22 @@ export const TeacherSettingsPage = () => {
                 </ConfirmErrorIcon>
                 <ConfirmErrorTextWrap>
                   <ConfirmErrorTitle>{classChangeErrorTitle}</ConfirmErrorTitle>
-                  <ConfirmErrorDescription>��� �� �ٽ� �õ����ּ���.</ConfirmErrorDescription>
+                  <ConfirmErrorDescription>잠시 후 다시 시도해주세요.</ConfirmErrorDescription>
                 </ConfirmErrorTextWrap>
               </ConfirmErrorBox>
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton
-                type="button"
-                variant="ghost"
-                size="L"
-                label="���"
-                onClick={handleCloseClassChangeConfirmModal}
-              />
+              <ModalGhostButton type="button" onClick={handleCloseClassChangeConfirmModal}>
+                취소
+              </ModalGhostButton>
               <ModalPrimaryButton
                 type="button"
-                variant="primary"
-                size="L"
-                label={isClassChangeSubmitting ? '���� ��...' : '�����ϱ�'}
                 onClick={handleConfirmClassChange}
                 disabled={isClassChangeSubmitting}
-              />
+              >
+                {isClassChangeSubmitting ? '변경 중...' : '변경하기'}
+              </ModalPrimaryButton>
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -809,11 +785,11 @@ export const TeacherSettingsPage = () => {
               <IcCheck />
             </SuccessIconWrap>
 
-            <ModalTitle>�б��� ����Ǿ����</ModalTitle>
+            <ModalTitle>학급이 변경되었어요</ModalTitle>
             <ModalDescription>
-              ���ο� �б� �ڵ尡 �߱޵Ǿ����.
+              새로운 학급 코드가 발급되었어요.
               <br />
-              �кθ�Բ� �� �ڵ带 �������ּ���.
+              학부모님께 새 코드를 전달해주세요.
             </ModalDescription>
 
             <SuccessCodeCard>
@@ -823,24 +799,14 @@ export const TeacherSettingsPage = () => {
               <SuccessCodeValue>{newClassCode || '-'}</SuccessCodeValue>
             </SuccessCodeCard>
 
-            <SuccessCopyButton
-              type="button"
-              variant="ghost"
-              size="L"
-              width="100%"
-              icon={IcCopy}
-              label="�б��ڵ� �����ϱ�"
-              onClick={handleCopyNewClassCode}
-            />
+            <SuccessCopyButton type="button" onClick={handleCopyNewClassCode}>
+              <IcCopy />
+              학급코드 복사하기
+            </SuccessCopyButton>
 
-            <SuccessConfirmButton
-              type="button"
-              variant="primary"
-              size="L"
-              width="100%"
-              label="Ȯ��"
-              onClick={handleCloseClassChangeSuccessModal}
-            />
+            <SuccessConfirmButton type="button" onClick={handleCloseClassChangeSuccessModal}>
+              확인
+            </SuccessConfirmButton>
           </ModalCard>
         </ModalOverlay>
       ) : null}
@@ -852,9 +818,9 @@ export const TeacherSettingsPage = () => {
               <IcError />
             </WithdrawIconWrap>
 
-            <ModalTitle>���� Ż���Ͻðھ��?</ModalTitle>
+            <ModalTitle>정말 탈퇴하시겠어요?</ModalTitle>
             <ModalDescription>
-              Ż���ϸ� �б� ������ ��ȭ ������ ��� �����ǰ�, �ٽ� ������ �� �����.
+              탈퇴하면 학급 정보와 대화 내역이 모두 삭제되고, 다시 복구할 수 없어요.
             </ModalDescription>
 
             {withdrawErrorMessage ? (
@@ -862,23 +828,18 @@ export const TeacherSettingsPage = () => {
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton
-                type="button"
-                variant="ghost"
-                size="L"
-                label="���"
-                onClick={handleCloseWithdrawModal}
-              />
+              <ModalGhostButton type="button" onClick={handleCloseWithdrawModal}>
+                취소
+              </ModalGhostButton>
               <WithdrawConfirmButton
                 type="button"
-                variant="primary"
-                size="L"
-                label={isWithdrawing ? 'Ż�� ��...' : 'Ż���ϱ�'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
                 disabled={isWithdrawing}
-              />
+              >
+                {isWithdrawing ? '탈퇴 중...' : '탈퇴하기'}
+              </WithdrawConfirmButton>
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -979,6 +940,29 @@ const WorkdayRow = styled.div`
   }
 `;
 
+const ToggleButton = styled.button<{ isEnabled: boolean }>`
+  width: 44px;
+  height: 26px;
+  border: none;
+  border-radius: 999px;
+  padding: 3px;
+  background: ${({ isEnabled, theme }) =>
+    isEnabled ? theme.colors.brand.primary : theme.colors.background.bg5};
+  display: flex;
+  align-items: center;
+  justify-content: ${({ isEnabled }) => (isEnabled ? 'flex-end' : 'flex-start')};
+  cursor: pointer;
+`;
+
+const ToggleThumb = styled.span<{ isEnabled: boolean }>`
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: ${({ isEnabled, theme }) =>
+    isEnabled ? theme.colors.background.bg1 : theme.colors.background.bg1};
+  box-shadow: ${({ theme }) => theme.colors.shadow.toggleThumb};
+`;
+
 const DayLabel = styled.span`
   ${({ theme }) => theme.fonts.labelXS};
   min-width: 20px;
@@ -997,15 +981,20 @@ const TimeRange = styled.div`
   }
 `;
 
-const TimeInput = styled(TextField)`
+const TimeInput = styled.input`
+  ${({ theme }) => theme.fonts.body2};
   width: 160px;
-  gap: 0;
+  border: 1px solid ${({ theme }) => theme.colors.border.border2};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text2};
+  padding: 10px 12px;
 
-  input {
-    color: ${({ theme }) => theme.colors.text.text2};
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.text4};
   }
 
-  input:disabled {
+  &:disabled {
     background: ${({ theme }) => theme.colors.background.bg3};
     color: ${({ theme }) => theme.colors.text.text4};
     cursor: not-allowed;
@@ -1081,9 +1070,22 @@ const ClassCodeBadge = styled.span`
   padding: 10px 18px;
 `;
 
-const CodeCopyButton = styled(InlineButton)`
-  height: 42px;
+const CodeCopyButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text1};
   padding: 10px 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   svg {
     width: 16px;
     height: 16px;
@@ -1098,20 +1100,14 @@ const AccountLinkList = styled.div`
   align-items: flex-start;
 `;
 
-const AccountLinkButton = styled(InlineButton)`
-  padding: 0;
-  height: auto;
-  justify-content: flex-start;
+const AccountLinkButton = styled.button`
+  ${({ theme }) => theme.fonts.body2};
+  color: ${({ theme }) => theme.colors.text.text1};
 `;
 
-const DangerLinkButton = styled(InlineButton)`
-  padding: 0;
-  height: auto;
-  justify-content: flex-start;
-
-  span {
-    color: ${({ theme }) => theme.colors.semantic.error};
-  }
+const DangerLinkButton = styled.button`
+  ${({ theme }) => theme.fonts.body2};
+  color: ${({ theme }) => theme.colors.semantic.error};
 `;
 
 const ModalOverlay = styled.div`
@@ -1208,9 +1204,23 @@ const RequiredAsterisk = styled.span`
   color: ${({ theme }) => theme.colors.semantic.error};
 `;
 
-const FormInput = styled(TextField)`
+const FormInput = styled.input`
+  ${({ theme }) => theme.fonts.body2};
   width: 100%;
-  gap: 0;
+  min-width: 0;
+  display: block;
+  border: 1px solid ${({ theme }) => theme.colors.border.border2};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text1};
+  padding: 10px 12px;
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+
+  &::placeholder {
+    color: ${({ theme }) => theme.colors.text.text4};
+  }
 `;
 
 const FormSelect = styled.select`
@@ -1313,18 +1323,40 @@ const SuccessCodeValue = styled.p`
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
-const SuccessCopyButton = styled(InlineButton)`
+const SuccessCopyButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
   margin-top: 10px;
-  height: 42px;
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text1};
+  padding: 11px 12px;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
   svg {
     width: 16px;
     height: 16px;
   }
 `;
 
-const SuccessConfirmButton = styled(InlineButton)`
+const SuccessConfirmButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
   margin-top: 14px;
-  height: 42px;
+  width: 100%;
+  border: none;
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.brand.primary};
+  color: ${({ theme }) => theme.colors.text.textW};
+  padding: 11px 12px;
 `;
 
 const ModalButtonRow = styled.div`
@@ -1334,14 +1366,28 @@ const ModalButtonRow = styled.div`
   gap: 10px;
 `;
 
-const ModalGhostButton = styled(InlineButton)`
-  width: 100%;
-  height: 42px;
+const ModalGhostButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text1};
+  padding: 11px 12px;
 `;
 
-const ModalPrimaryButton = styled(InlineButton)`
-  width: 100%;
-  height: 42px;
+const ModalPrimaryButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
+  border: none;
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.brand.primary};
+  color: ${({ theme }) => theme.colors.text.textW};
+  padding: 11px 12px;
+
+  &:disabled {
+    background: ${({ theme }) => theme.colors.background.bg5};
+    color: ${({ theme }) => theme.colors.text.text4};
+    cursor: not-allowed;
+  }
 `;
 
 const WithdrawConfirmButton = styled(ModalPrimaryButton)`

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -1,4 +1,4 @@
-﻿import styled from '@emotion/styled';
+import styled from '@emotion/styled';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AxiosError } from 'axios';
 import { useOutletContext } from 'react-router-dom';
@@ -25,13 +25,13 @@ const EMPTY_TIME = '';
 const TIME_PLACEHOLDER = '00:00';
 
 const DAY_INFO: { key: WorkdayKey; dayOfWeek: number; label: string }[] = [
-  { key: 'mon', dayOfWeek: 1, label: '월' },
-  { key: 'tue', dayOfWeek: 2, label: '화' },
-  { key: 'wed', dayOfWeek: 3, label: '수' },
-  { key: 'thu', dayOfWeek: 4, label: '목' },
-  { key: 'fri', dayOfWeek: 5, label: '금' },
-  { key: 'sat', dayOfWeek: 6, label: '토' },
-  { key: 'sun', dayOfWeek: 7, label: '일' },
+  { key: 'mon', dayOfWeek: 1, label: '��' },
+  { key: 'tue', dayOfWeek: 2, label: 'ȭ' },
+  { key: 'wed', dayOfWeek: 3, label: '��' },
+  { key: 'thu', dayOfWeek: 4, label: '��' },
+  { key: 'fri', dayOfWeek: 5, label: '��' },
+  { key: 'sat', dayOfWeek: 6, label: '��' },
+  { key: 'sun', dayOfWeek: 7, label: '��' },
 ];
 
 const toDisplayTime = (value: string | null | undefined) => {
@@ -158,7 +158,7 @@ export const TeacherSettingsPage = () => {
         }
 
         const axiosError = error as AxiosError<{ message?: string }>;
-        setErrorMessage(axiosError.response?.data?.message || '설정 정보를 불러오지 못했어요.');
+        setErrorMessage(axiosError.response?.data?.message || '���� ������ �ҷ����� ���߾��.');
       } finally {
         if (isMounted) {
           setIsLoading(false);
@@ -197,13 +197,13 @@ export const TeacherSettingsPage = () => {
       return '-';
     }
 
-    return `${gradeInput}학년 ${classInput}`;
+    return `${gradeInput}�г� ${classInput}`;
   }, [classInput, gradeInput]);
 
   const handleOpenClassChangeModal = () => {
     setSchoolNameInput(setting?.schoolName ?? '');
     setGradeInput(setting?.grade != null ? String(setting.grade) : '');
-    setClassInput(setting?.classNumber != null ? `${setting.classNumber}반` : '');
+    setClassInput(setting?.classNumber != null ? `${setting.classNumber}��` : '');
     setIsClassChangeModalOpen(true);
   };
 
@@ -238,7 +238,7 @@ export const TeacherSettingsPage = () => {
     const classNumber = extractClassNumber(classInput.trim());
 
     if (!classNumber) {
-      setClassChangeErrorTitle('반 정보를 확인해주세요.');
+      setClassChangeErrorTitle('�� ������ Ȯ�����ּ���.');
       return;
     }
 
@@ -252,7 +252,7 @@ export const TeacherSettingsPage = () => {
       });
 
       if (!response.success) {
-        setClassChangeErrorTitle(response.message || '학급 변경에 실패했어요.');
+        setClassChangeErrorTitle(response.message || '�б� ���濡 �����߾��.');
         return;
       }
 
@@ -275,7 +275,7 @@ export const TeacherSettingsPage = () => {
       setIsClassChangeSuccessModalOpen(true);
     } catch (error) {
       const axiosError = error as AxiosError<{ message?: string }>;
-      setClassChangeErrorTitle(axiosError.response?.data?.message || '학급 변경에 실패했어요.');
+      setClassChangeErrorTitle(axiosError.response?.data?.message || '�б� ���濡 �����߾��.');
     } finally {
       setIsClassChangeSubmitting(false);
     }
@@ -285,20 +285,20 @@ export const TeacherSettingsPage = () => {
     const classCode = rawClassCode?.trim();
 
     if (!classCode) {
-      showToast('복사할 학급코드가 없어요.', 'error');
+      showToast('������ �б��ڵ尡 �����.', 'error');
       return;
     }
 
     if (!navigator.clipboard) {
-      showToast('현재 브라우저에서는 복사를 지원하지 않아요.', 'error');
+      showToast('���� ������������ ���縦 �������� �ʾƿ�.', 'error');
       return;
     }
 
     try {
       await navigator.clipboard.writeText(classCode);
-      showToast('학급코드를 복사했어요.', 'success');
+      showToast('�б��ڵ带 �����߾��.', 'success');
     } catch {
-      showToast('학급코드 복사에 실패했어요.', 'error');
+      showToast('�б��ڵ� ���翡 �����߾��.', 'error');
     }
   };
 
@@ -371,7 +371,7 @@ export const TeacherSettingsPage = () => {
     }
 
     setWorkdays(initialWorkdays);
-    showToast('근무시간 입력값을 되돌렸어요.', 'success');
+    showToast('�ٹ��ð� �Է°��� �ǵ��Ⱦ��.', 'success');
   }, [hasWorkHoursChanges, initialWorkdays, isLoading, showToast]);
 
   const handleSaveWorkHours = useCallback(async () => {
@@ -381,7 +381,7 @@ export const TeacherSettingsPage = () => {
 
     const enabledWorkdays = workdays.filter(day => day.enabled);
     if (enabledWorkdays.length === 0) {
-      showToast('근무 요일을 1개 이상 활성화해주세요.', 'error');
+      showToast('�ٹ� ������ 1�� �̻� Ȱ��ȭ���ּ���.', 'error');
       return;
     }
 
@@ -390,7 +390,7 @@ export const TeacherSettingsPage = () => {
     );
 
     if (invalidWorkday) {
-      showToast(`${invalidWorkday.label}요일 시간을 HH:mm 형식으로 입력해주세요.`, 'error');
+      showToast(`${invalidWorkday.label}���� �ð��� HH:mm �������� �Է����ּ���.`, 'error');
       return;
     }
 
@@ -398,7 +398,7 @@ export const TeacherSettingsPage = () => {
       day => toMinutes(day.start) >= toMinutes(day.end)
     );
     if (invalidOrderWorkday) {
-      showToast(`${invalidOrderWorkday.label}요일 종료 시간은 시작 시간보다 늦어야 해요.`, 'error');
+      showToast(`${invalidOrderWorkday.label}���� ���� �ð��� ���� �ð����� �ʾ�� �ؿ�.`, 'error');
       return;
     }
 
@@ -420,8 +420,8 @@ export const TeacherSettingsPage = () => {
         const failMessage = response.message?.trim()
           ? response.message
           : response.code
-            ? `근무시간 저장에 실패했어요. (code: ${response.code})`
-            : '근무시간 저장에 실패했어요.';
+            ? `�ٹ��ð� ���忡 �����߾��. (code: ${response.code})`
+            : '�ٹ��ð� ���忡 �����߾��.';
         showToast(failMessage, 'error');
         return;
       }
@@ -442,7 +442,7 @@ export const TeacherSettingsPage = () => {
       });
 
       setInitialWorkdays(workdays);
-      showToast('근무시간이 저장되었어요.', 'success');
+      showToast('�ٹ��ð��� ����Ǿ����.', 'success');
     } catch (error) {
       const axiosError = error as AxiosError<{
         message?: string;
@@ -454,7 +454,7 @@ export const TeacherSettingsPage = () => {
         axiosError.response?.data?.error?.message ??
         axiosError.message;
       showToast(
-        `${serverMessage || '근무시간 저장에 실패했어요.'}${status ? ` (HTTP ${status})` : ''}`,
+        `${serverMessage || '�ٹ��ð� ���忡 �����߾��.'}${status ? ` (HTTP ${status})` : ''}`,
         'error'
       );
     } finally {
@@ -474,7 +474,7 @@ export const TeacherSettingsPage = () => {
     <PageContainer>
       <ContentArea>
         <CardSection>
-          <SectionTitle>프로필 정보</SectionTitle>
+          <SectionTitle>������ ����</SectionTitle>
           <ProfileRow>
             <AvatarCircle>{profileInitial}</AvatarCircle>
             <ProfileName>{profileName}</ProfileName>
@@ -483,19 +483,19 @@ export const TeacherSettingsPage = () => {
 
         <CardSection>
           <SectionHeader>
-            <SectionTitle>근무시간 설정</SectionTitle>
+            <SectionTitle>�ٹ��ð� ����</SectionTitle>
             <SectionActionGroup>
               <InlineButton
                 variant="ghost"
                 size="L"
-                label="취소"
+                label="���"
                 disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
                 onClick={handleResetWorkHours}
               />
               <InlineButton
                 variant="primary"
                 size="L"
-                label={isSavingWorkHours ? '저장 중...' : '변경사항 저장'}
+                label={isSavingWorkHours ? '���� ��...' : '������� ����'}
                 disabled={isLoading || isSavingWorkHours || !hasWorkHoursChanges}
                 onClick={() => {
                   void handleSaveWorkHours();
@@ -504,11 +504,11 @@ export const TeacherSettingsPage = () => {
             </SectionActionGroup>
           </SectionHeader>
           <SectionDescription>
-            학부모님들이 메시지를 보낼 때 참고할 수 있는 시간이에요. 근무 시간 외에는 확인이 늦어질
-            수 있다는 안내를 해드려요.
+            �кθ�Ե��� �޽����� ���� �� ������ �� �ִ� �ð��̿���. �ٹ� �ð� �ܿ��� Ȯ���� �ʾ��� �� �ִٴ� �ȳ���
+            �ص����.
           </SectionDescription>
 
-          {isLoading ? <StateText>설정 정보를 불러오는 중이에요...</StateText> : null}
+          {isLoading ? <StateText>���� ������ �ҷ����� ���̿���...</StateText> : null}
           {!isLoading && errorMessage ? <ErrorText>{errorMessage}</ErrorText> : null}
 
           {!isLoading && !errorMessage ? (
@@ -517,7 +517,7 @@ export const TeacherSettingsPage = () => {
                 <WorkdayRow key={day.key}>
                   <ToggleSwitch
                     checked={day.enabled}
-                    ariaLabel={`${day.label} 요일 근무시간 사용`}
+                    ariaLabel={`${day.label} ���� �ٹ��ð� ���`}
                     onToggle={() => handleToggleWorkday(day.key)}
                   />
 
@@ -556,23 +556,23 @@ export const TeacherSettingsPage = () => {
 
         <CardSection>
           <SectionHeader>
-            <SectionTitle>학급 관리</SectionTitle>
+            <SectionTitle>�б� ����</SectionTitle>
             <InlineButton
               type="button"
               variant="primary"
               size="L"
-              label="학급 변경하기"
+              label="�б� �����ϱ�"
               onClick={handleOpenClassChangeModal}
             />
           </SectionHeader>
 
           <ClassInfoGrid>
-            <InfoLabel>학교명</InfoLabel>
+            <InfoLabel>�б���</InfoLabel>
             <InfoValue>{setting?.schoolName?.trim() ? setting.schoolName : '-'}</InfoValue>
-            <InfoLabel>학급</InfoLabel>
+            <InfoLabel>�б�</InfoLabel>
             <InfoValue>
               {setting?.grade != null && setting?.classNumber != null
-                ? `${setting.grade}학년 ${setting.classNumber}반`
+                ? `${setting.grade}�г� ${setting.classNumber}��`
                 : '-'}
             </InfoValue>
           </ClassInfoGrid>
@@ -580,7 +580,7 @@ export const TeacherSettingsPage = () => {
           <Divider />
 
           <ClassCodeWrap>
-            <InfoLabel>학급 코드</InfoLabel>
+            <InfoLabel>�б� �ڵ�</InfoLabel>
             <ClassCodeActions>
               <ClassCodeBadge>
                 {setting?.classCode?.trim() ? setting.classCode : '-'}
@@ -590,7 +590,7 @@ export const TeacherSettingsPage = () => {
                 variant="ghost"
                 size="L"
                 icon={IcCopy}
-                label="학급코드 복사하기"
+                label="�б��ڵ� �����ϱ�"
                 onClick={handleCopyClassCode}
               />
             </ClassCodeActions>
@@ -598,20 +598,20 @@ export const TeacherSettingsPage = () => {
         </CardSection>
 
         <CardSection>
-          <SectionTitle>계정 관리</SectionTitle>
+          <SectionTitle>���� ����</SectionTitle>
           <AccountLinkList>
             <AccountLinkButton
               type="button"
               variant="text"
               size="L"
-              label="로그아웃"
+              label="�α׾ƿ�"
               onClick={handleLogout}
             />
             <DangerLinkButton
               type="button"
               variant="text"
               size="L"
-              label="회원 탈퇴"
+              label="ȸ�� Ż��"
               onClick={handleOpenWithdrawModal}
             />
           </AccountLinkList>
@@ -625,11 +625,11 @@ export const TeacherSettingsPage = () => {
               <IcInfo />
             </ConfirmIconWrap>
 
-            <ModalTitle>회원 탈퇴하시겠어요?</ModalTitle>
+            <ModalTitle>ȸ�� Ż���Ͻðھ��?</ModalTitle>
             <ModalDescription>
-              탈퇴하면 계정 정보가 삭제되며 복구할 수 없어요.
+              Ż���ϸ� ���� ������ �����Ǹ� ������ �� �����.
               <br />
-              정말 탈퇴하시려면 아래 버튼을 눌러 주세요.
+              ���� Ż���Ͻ÷��� �Ʒ� ��ư�� ���� �ּ���.
             </ModalDescription>
 
             {withdrawErrorMessage ? (
@@ -639,7 +639,7 @@ export const TeacherSettingsPage = () => {
                 </ConfirmErrorIcon>
                 <ConfirmErrorTextWrap>
                   <ConfirmErrorTitle>{withdrawErrorMessage}</ConfirmErrorTitle>
-                  <ConfirmErrorDescription>잠시 후 다시 시도해 주세요.</ConfirmErrorDescription>
+                  <ConfirmErrorDescription>��� �� �ٽ� �õ��� �ּ���.</ConfirmErrorDescription>
                 </ConfirmErrorTextWrap>
               </ConfirmErrorBox>
             ) : null}
@@ -649,14 +649,14 @@ export const TeacherSettingsPage = () => {
                 type="button"
                 variant="ghost"
                 size="L"
-                label="취소"
+                label="���"
                 onClick={handleCloseWithdrawModal}
               />
               <ModalPrimaryButton
                 type="button"
                 variant="primary"
                 size="L"
-                label={isWithdrawing ? '탈퇴 중...' : '회원 탈퇴'}
+                label={isWithdrawing ? 'Ż�� ��...' : 'ȸ�� Ż��'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
@@ -674,20 +674,20 @@ export const TeacherSettingsPage = () => {
               <IcChange />
             </ModalIconWrap>
 
-            <ModalTitle>학급 변경</ModalTitle>
+            <ModalTitle>�б� ����</ModalTitle>
             <ModalDescription>
-              새 학급 정보를 입력해주세요. 변경이 완료되면 새로운 학급 코드가 발급돼요.
+              �� �б� ������ �Է����ּ���. ������ �Ϸ�Ǹ� ���ο� �б� �ڵ尡 �߱޵ſ�.
             </ModalDescription>
 
             <ModalForm>
               <FormGroup>
                 <FormLabel>
-                  학교명 <RequiredAsterisk>*</RequiredAsterisk>
+                  �б��� <RequiredAsterisk>*</RequiredAsterisk>
                 </FormLabel>
                 <FormInput
                   value={schoolNameInput}
                   onChange={event => setSchoolNameInput(event.target.value)}
-                  placeholder="학교명을 입력해주세요."
+                  placeholder="�б����� �Է����ּ���."
                   autoComplete="off"
                 />
               </FormGroup>
@@ -695,30 +695,30 @@ export const TeacherSettingsPage = () => {
               <FormRow>
                 <FormGroup>
                   <FormLabel>
-                    학년 <RequiredAsterisk>*</RequiredAsterisk>
+                    �г� <RequiredAsterisk>*</RequiredAsterisk>
                   </FormLabel>
                   <FormSelect
                     value={gradeInput}
                     onChange={event => setGradeInput(event.target.value)}
                   >
-                    <option value="">학년을 선택해주세요.</option>
-                    <option value="1">1학년</option>
-                    <option value="2">2학년</option>
-                    <option value="3">3학년</option>
-                    <option value="4">4학년</option>
-                    <option value="5">5학년</option>
-                    <option value="6">6학년</option>
+                    <option value="">�г��� �������ּ���.</option>
+                    <option value="1">1�г�</option>
+                    <option value="2">2�г�</option>
+                    <option value="3">3�г�</option>
+                    <option value="4">4�г�</option>
+                    <option value="5">5�г�</option>
+                    <option value="6">6�г�</option>
                   </FormSelect>
                 </FormGroup>
 
                 <FormGroup>
                   <FormLabel>
-                    반 <RequiredAsterisk>*</RequiredAsterisk>
+                    �� <RequiredAsterisk>*</RequiredAsterisk>
                   </FormLabel>
                   <FormInput
                     value={classInput}
                     onChange={event => setClassInput(event.target.value)}
-                    placeholder="2반"
+                    placeholder="2��"
                     autoComplete="off"
                   />
                 </FormGroup>
@@ -730,14 +730,14 @@ export const TeacherSettingsPage = () => {
                 type="button"
                 variant="ghost"
                 size="L"
-                label="취소"
+                label="���"
                 onClick={handleCloseClassChangeModal}
               />
               <ModalPrimaryButton
                 type="button"
                 variant="primary"
                 size="L"
-                label="변경하기"
+                label="�����ϱ�"
                 disabled={!isClassChangeEnabled}
                 onClick={handleOpenClassChangeConfirmModal}
               />
@@ -753,19 +753,18 @@ export const TeacherSettingsPage = () => {
               <IcInfo />
             </ConfirmIconWrap>
 
-            <ModalTitle>학급을 변경할까요?</ModalTitle>
+            <ModalTitle>�б��� �����ұ��?</ModalTitle>
             <ModalDescription>
-              학급을 변경하면 새로운 학급 코드가 발급돼요. 기존 학급 코드는 더 이상 사용할 수
-              없어요.
+              �б��� �����ϸ� ���ο� �б� �ڵ尡 �߱޵ſ�. ���� �б� �ڵ�� �� �̻� ����� �� �����.
             </ModalDescription>
 
             <ConfirmSummaryBox>
               <ConfirmSummaryRow>
-                <ConfirmSummaryLabel>학교명</ConfirmSummaryLabel>
+                <ConfirmSummaryLabel>�б���</ConfirmSummaryLabel>
                 <ConfirmSummaryValue>{schoolNameInput || '-'}</ConfirmSummaryValue>
               </ConfirmSummaryRow>
               <ConfirmSummaryRow>
-                <ConfirmSummaryLabel>학급</ConfirmSummaryLabel>
+                <ConfirmSummaryLabel>�б�</ConfirmSummaryLabel>
                 <ConfirmSummaryValue>{classSummaryText}</ConfirmSummaryValue>
               </ConfirmSummaryRow>
             </ConfirmSummaryBox>
@@ -777,7 +776,7 @@ export const TeacherSettingsPage = () => {
                 </ConfirmErrorIcon>
                 <ConfirmErrorTextWrap>
                   <ConfirmErrorTitle>{classChangeErrorTitle}</ConfirmErrorTitle>
-                  <ConfirmErrorDescription>잠시 후 다시 시도해주세요.</ConfirmErrorDescription>
+                  <ConfirmErrorDescription>��� �� �ٽ� �õ����ּ���.</ConfirmErrorDescription>
                 </ConfirmErrorTextWrap>
               </ConfirmErrorBox>
             ) : null}
@@ -787,14 +786,14 @@ export const TeacherSettingsPage = () => {
                 type="button"
                 variant="ghost"
                 size="L"
-                label="취소"
+                label="���"
                 onClick={handleCloseClassChangeConfirmModal}
               />
               <ModalPrimaryButton
                 type="button"
                 variant="primary"
                 size="L"
-                label={isClassChangeSubmitting ? '변경 중...' : '변경하기'}
+                label={isClassChangeSubmitting ? '���� ��...' : '�����ϱ�'}
                 onClick={handleConfirmClassChange}
                 disabled={isClassChangeSubmitting}
               />
@@ -810,11 +809,11 @@ export const TeacherSettingsPage = () => {
               <IcCheck />
             </SuccessIconWrap>
 
-            <ModalTitle>학급이 변경되었어요</ModalTitle>
+            <ModalTitle>�б��� ����Ǿ����</ModalTitle>
             <ModalDescription>
-              새로운 학급 코드가 발급되었어요.
+              ���ο� �б� �ڵ尡 �߱޵Ǿ����.
               <br />
-              학부모님께 새 코드를 전달해주세요.
+              �кθ�Բ� �� �ڵ带 �������ּ���.
             </ModalDescription>
 
             <SuccessCodeCard>
@@ -830,7 +829,7 @@ export const TeacherSettingsPage = () => {
               size="L"
               width="100%"
               icon={IcCopy}
-              label="학급코드 복사하기"
+              label="�б��ڵ� �����ϱ�"
               onClick={handleCopyNewClassCode}
             />
 
@@ -839,7 +838,7 @@ export const TeacherSettingsPage = () => {
               variant="primary"
               size="L"
               width="100%"
-              label="확인"
+              label="Ȯ��"
               onClick={handleCloseClassChangeSuccessModal}
             />
           </ModalCard>
@@ -853,9 +852,9 @@ export const TeacherSettingsPage = () => {
               <IcError />
             </WithdrawIconWrap>
 
-            <ModalTitle>정말 탈퇴하시겠어요?</ModalTitle>
+            <ModalTitle>���� Ż���Ͻðھ��?</ModalTitle>
             <ModalDescription>
-              탈퇴하면 학급 정보와 대화 내역이 모두 삭제되고, 다시 복구할 수 없어요.
+              Ż���ϸ� �б� ������ ��ȭ ������ ��� �����ǰ�, �ٽ� ������ �� �����.
             </ModalDescription>
 
             {withdrawErrorMessage ? (
@@ -867,14 +866,14 @@ export const TeacherSettingsPage = () => {
                 type="button"
                 variant="ghost"
                 size="L"
-                label="취소"
+                label="���"
                 onClick={handleCloseWithdrawModal}
               />
               <WithdrawConfirmButton
                 type="button"
                 variant="primary"
                 size="L"
-                label={isWithdrawing ? '탈퇴 중...' : '탈퇴하기'}
+                label={isWithdrawing ? 'Ż�� ��...' : 'Ż���ϱ�'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
@@ -1119,7 +1118,7 @@ const ModalOverlay = styled.div`
   position: fixed;
   inset: 0;
   z-index: 1200;
-  background: ${({ theme }) => theme.colors.overlay.dim2};
+  background: ${({ theme }) => theme.colors.overlay.dim};
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -1,8 +1,10 @@
-import styled from '@emotion/styled';
+﻿import styled from '@emotion/styled';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AxiosError } from 'axios';
 import { useOutletContext } from 'react-router-dom';
 import { InlineButton } from '@/components/common/InlineButton';
+import { TextField } from '@/components/common/TextField';
+import { ToggleSwitch } from '@/components/common/ToggleSwitch';
 import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
 import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
 import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
@@ -513,15 +515,11 @@ export const TeacherSettingsPage = () => {
             <WorkdayList>
               {workdays.map(day => (
                 <WorkdayRow key={day.key}>
-                  <ToggleButton
-                    type="button"
-                    isEnabled={day.enabled}
-                    aria-pressed={day.enabled}
-                    aria-label={`${day.label}요일 근무시간 사용`}
-                    onClick={() => handleToggleWorkday(day.key)}
-                  >
-                    <ToggleThumb isEnabled={day.enabled} />
-                  </ToggleButton>
+                  <ToggleSwitch
+                    checked={day.enabled}
+                    ariaLabel={`${day.label} 요일 근무시간 사용`}
+                    onToggle={() => handleToggleWorkday(day.key)}
+                  />
 
                   <DayLabel>{day.label}</DayLabel>
 
@@ -587,10 +585,14 @@ export const TeacherSettingsPage = () => {
               <ClassCodeBadge>
                 {setting?.classCode?.trim() ? setting.classCode : '-'}
               </ClassCodeBadge>
-              <CodeCopyButton type="button" onClick={handleCopyClassCode}>
-                <IcCopy />
-                학급코드 복사하기
-              </CodeCopyButton>
+              <CodeCopyButton
+                type="button"
+                variant="ghost"
+                size="L"
+                icon={IcCopy}
+                label="학급코드 복사하기"
+                onClick={handleCopyClassCode}
+              />
             </ClassCodeActions>
           </ClassCodeWrap>
         </CardSection>
@@ -598,12 +600,20 @@ export const TeacherSettingsPage = () => {
         <CardSection>
           <SectionTitle>계정 관리</SectionTitle>
           <AccountLinkList>
-            <AccountLinkButton type="button" onClick={handleLogout}>
-              로그아웃
-            </AccountLinkButton>
-            <DangerLinkButton type="button" onClick={handleOpenWithdrawModal}>
-              회원 탈퇴
-            </DangerLinkButton>
+            <AccountLinkButton
+              type="button"
+              variant="text"
+              size="L"
+              label="로그아웃"
+              onClick={handleLogout}
+            />
+            <DangerLinkButton
+              type="button"
+              variant="text"
+              size="L"
+              label="회원 탈퇴"
+              onClick={handleOpenWithdrawModal}
+            />
           </AccountLinkList>
         </CardSection>
       </ContentArea>
@@ -635,18 +645,23 @@ export const TeacherSettingsPage = () => {
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton type="button" onClick={handleCloseWithdrawModal}>
-                취소
-              </ModalGhostButton>
+              <ModalGhostButton
+                type="button"
+                variant="ghost"
+                size="L"
+                label="취소"
+                onClick={handleCloseWithdrawModal}
+              />
               <ModalPrimaryButton
                 type="button"
+                variant="primary"
+                size="L"
+                label={isWithdrawing ? '탈퇴 중...' : '회원 탈퇴'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
                 disabled={isWithdrawing}
-              >
-                {isWithdrawing ? '탈퇴 중...' : '회원 탈퇴'}
-              </ModalPrimaryButton>
+              />
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -711,16 +726,21 @@ export const TeacherSettingsPage = () => {
             </ModalForm>
 
             <ModalButtonRow>
-              <ModalGhostButton type="button" onClick={handleCloseClassChangeModal}>
-                취소
-              </ModalGhostButton>
+              <ModalGhostButton
+                type="button"
+                variant="ghost"
+                size="L"
+                label="취소"
+                onClick={handleCloseClassChangeModal}
+              />
               <ModalPrimaryButton
                 type="button"
+                variant="primary"
+                size="L"
+                label="변경하기"
                 disabled={!isClassChangeEnabled}
                 onClick={handleOpenClassChangeConfirmModal}
-              >
-                변경하기
-              </ModalPrimaryButton>
+              />
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -763,16 +783,21 @@ export const TeacherSettingsPage = () => {
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton type="button" onClick={handleCloseClassChangeConfirmModal}>
-                취소
-              </ModalGhostButton>
+              <ModalGhostButton
+                type="button"
+                variant="ghost"
+                size="L"
+                label="취소"
+                onClick={handleCloseClassChangeConfirmModal}
+              />
               <ModalPrimaryButton
                 type="button"
+                variant="primary"
+                size="L"
+                label={isClassChangeSubmitting ? '변경 중...' : '변경하기'}
                 onClick={handleConfirmClassChange}
                 disabled={isClassChangeSubmitting}
-              >
-                {isClassChangeSubmitting ? '변경 중...' : '변경하기'}
-              </ModalPrimaryButton>
+              />
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -799,14 +824,24 @@ export const TeacherSettingsPage = () => {
               <SuccessCodeValue>{newClassCode || '-'}</SuccessCodeValue>
             </SuccessCodeCard>
 
-            <SuccessCopyButton type="button" onClick={handleCopyNewClassCode}>
-              <IcCopy />
-              학급코드 복사하기
-            </SuccessCopyButton>
+            <SuccessCopyButton
+              type="button"
+              variant="ghost"
+              size="L"
+              width="100%"
+              icon={IcCopy}
+              label="학급코드 복사하기"
+              onClick={handleCopyNewClassCode}
+            />
 
-            <SuccessConfirmButton type="button" onClick={handleCloseClassChangeSuccessModal}>
-              확인
-            </SuccessConfirmButton>
+            <SuccessConfirmButton
+              type="button"
+              variant="primary"
+              size="L"
+              width="100%"
+              label="확인"
+              onClick={handleCloseClassChangeSuccessModal}
+            />
           </ModalCard>
         </ModalOverlay>
       ) : null}
@@ -828,18 +863,23 @@ export const TeacherSettingsPage = () => {
             ) : null}
 
             <ModalButtonRow>
-              <ModalGhostButton type="button" onClick={handleCloseWithdrawModal}>
-                취소
-              </ModalGhostButton>
+              <ModalGhostButton
+                type="button"
+                variant="ghost"
+                size="L"
+                label="취소"
+                onClick={handleCloseWithdrawModal}
+              />
               <WithdrawConfirmButton
                 type="button"
+                variant="primary"
+                size="L"
+                label={isWithdrawing ? '탈퇴 중...' : '탈퇴하기'}
                 onClick={() => {
                   void handleConfirmWithdraw();
                 }}
                 disabled={isWithdrawing}
-              >
-                {isWithdrawing ? '탈퇴 중...' : '탈퇴하기'}
-              </WithdrawConfirmButton>
+              />
             </ModalButtonRow>
           </ModalCard>
         </ModalOverlay>
@@ -905,7 +945,7 @@ const AvatarCircle = styled.span`
   width: 40px;
   height: 40px;
   border-radius: 999px;
-  background: ${({ theme }) => theme.colors.teacherSettings.avatarBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   color: ${({ theme }) => theme.colors.brand.dark};
   display: inline-flex;
   align-items: center;
@@ -928,7 +968,7 @@ const WorkdayList = styled.div`
 const WorkdayRow = styled.div`
   border-radius: 14px;
   border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  background: ${({ theme }) => theme.colors.teacherSettings.workdayRowBackground};
+  background: ${({ theme }) => theme.colors.background.bg3};
   padding: 12px 14px;
   display: flex;
   align-items: center;
@@ -938,31 +978,6 @@ const WorkdayRow = styled.div`
     flex-wrap: wrap;
     gap: 10px;
   }
-`;
-
-const ToggleButton = styled.button<{ isEnabled: boolean }>`
-  width: 44px;
-  height: 26px;
-  border: none;
-  border-radius: 999px;
-  padding: 3px;
-  background: ${({ isEnabled, theme }) =>
-    isEnabled ? theme.colors.brand.primary : theme.colors.teacherSettings.toggleOffBackground};
-  display: flex;
-  align-items: center;
-  justify-content: ${({ isEnabled }) => (isEnabled ? 'flex-end' : 'flex-start')};
-  cursor: pointer;
-`;
-
-const ToggleThumb = styled.span<{ isEnabled: boolean }>`
-  width: 20px;
-  height: 20px;
-  border-radius: 999px;
-  background: ${({ isEnabled, theme }) =>
-    isEnabled
-      ? theme.colors.background.bg1
-      : theme.colors.teacherSettings.toggleThumbOffBackground};
-  box-shadow: ${({ theme }) => theme.colors.shadow.toggleThumb};
 `;
 
 const DayLabel = styled.span`
@@ -983,21 +998,16 @@ const TimeRange = styled.div`
   }
 `;
 
-const TimeInput = styled.input`
-  ${({ theme }) => theme.fonts.body2};
+const TimeInput = styled(TextField)`
   width: 160px;
-  border: 1px solid ${({ theme }) => theme.colors.border.border2};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text2};
-  padding: 10px 12px;
+  gap: 0;
 
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.text.text4};
+  input {
+    color: ${({ theme }) => theme.colors.text.text2};
   }
 
-  &:disabled {
-    background: ${({ theme }) => theme.colors.teacherSettings.inputDisabledBackground};
+  input:disabled {
+    background: ${({ theme }) => theme.colors.background.bg3};
     color: ${({ theme }) => theme.colors.text.text4};
     cursor: not-allowed;
   }
@@ -1066,28 +1076,15 @@ const ClassCodeActions = styled.div`
 const ClassCodeBadge = styled.span`
   ${({ theme }) => theme.fonts.labelS};
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.teacherSettings.classCodeBadgeBorder};
-  background: ${({ theme }) => theme.colors.teacherSettings.classCodeBadgeBackground};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg4};
   color: ${({ theme }) => theme.colors.text.text1};
   padding: 10px 18px;
 `;
 
-const CodeCopyButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text1};
+const CodeCopyButton = styled(InlineButton)`
+  height: 42px;
   padding: 10px 12px;
-  display: inline-flex;
-  align-items: center;
-  gap: 8px;
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
   svg {
     width: 16px;
     height: 16px;
@@ -1102,14 +1099,20 @@ const AccountLinkList = styled.div`
   align-items: flex-start;
 `;
 
-const AccountLinkButton = styled.button`
-  ${({ theme }) => theme.fonts.body2};
-  color: ${({ theme }) => theme.colors.text.text1};
+const AccountLinkButton = styled(InlineButton)`
+  padding: 0;
+  height: auto;
+  justify-content: flex-start;
 `;
 
-const DangerLinkButton = styled.button`
-  ${({ theme }) => theme.fonts.body2};
-  color: ${({ theme }) => theme.colors.semantic.error};
+const DangerLinkButton = styled(InlineButton)`
+  padding: 0;
+  height: auto;
+  justify-content: flex-start;
+
+  span {
+    color: ${({ theme }) => theme.colors.semantic.error};
+  }
 `;
 
 const ModalOverlay = styled.div`
@@ -1136,7 +1139,7 @@ const ModalIconWrap = styled.div`
   width: 58px;
   height: 58px;
   border-radius: 999px;
-  background: ${({ theme }) => theme.colors.teacherSettings.modalIconBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   color: ${({ theme }) => theme.colors.brand.dark};
   display: flex;
   align-items: center;
@@ -1150,12 +1153,12 @@ const ModalIconWrap = styled.div`
 `;
 
 const ConfirmIconWrap = styled(ModalIconWrap)`
-  background: ${({ theme }) => theme.colors.teacherSettings.confirmIconBackground};
-  color: ${({ theme }) => theme.colors.teacherSettings.confirmIconColor};
+  background: ${({ theme }) => theme.colors.semantic.warningSoft};
+  color: ${({ theme }) => theme.colors.semantic.warning};
 `;
 
 const SuccessIconWrap = styled(ModalIconWrap)`
-  background: ${({ theme }) => theme.colors.teacherSettings.modalIconBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   color: ${({ theme }) => theme.colors.brand.dark};
 `;
 
@@ -1206,23 +1209,9 @@ const RequiredAsterisk = styled.span`
   color: ${({ theme }) => theme.colors.semantic.error};
 `;
 
-const FormInput = styled.input`
-  ${({ theme }) => theme.fonts.body2};
+const FormInput = styled(TextField)`
   width: 100%;
-  min-width: 0;
-  display: block;
-  border: 1px solid ${({ theme }) => theme.colors.border.border2};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text1};
-  padding: 10px 12px;
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-
-  &::placeholder {
-    color: ${({ theme }) => theme.colors.text.text4};
-  }
+  gap: 0;
 `;
 
 const FormSelect = styled.select`
@@ -1240,8 +1229,8 @@ const FormSelect = styled.select`
 const ConfirmSummaryBox = styled.div`
   margin-top: 18px;
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.teacherSettings.confirmSummaryBorder};
-  background: ${({ theme }) => theme.colors.teacherSettings.confirmSummaryBackground};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 12px;
   display: flex;
   flex-direction: column;
@@ -1268,8 +1257,8 @@ const ConfirmSummaryValue = styled.span`
 const ConfirmErrorBox = styled.div`
   margin-top: 14px;
   border-radius: 12px;
-  border: 1px solid ${({ theme }) => theme.colors.teacherSettings.confirmErrorBorder};
-  background: ${({ theme }) => theme.colors.teacherSettings.confirmErrorBackground};
+  border: 1px solid ${({ theme }) => theme.colors.semantic.error};
+  background: ${({ theme }) => theme.colors.semantic.errorSoft};
   padding: 10px 12px;
   display: flex;
   align-items: center;
@@ -1307,8 +1296,8 @@ const ConfirmErrorDescription = styled.p`
 const SuccessCodeCard = styled.div`
   margin-top: 16px;
   border-radius: 14px;
-  border: 1px solid ${({ theme }) => theme.colors.teacherSettings.confirmSummaryBorder};
-  background: ${({ theme }) => theme.colors.teacherSettings.confirmSummaryBackground};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 14px;
   text-align: center;
 `;
@@ -1325,40 +1314,18 @@ const SuccessCodeValue = styled.p`
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
-const SuccessCopyButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
+const SuccessCopyButton = styled(InlineButton)`
   margin-top: 10px;
-  width: 100%;
-  border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text1};
-  padding: 11px 12px;
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
-
+  height: 42px;
   svg {
     width: 16px;
     height: 16px;
   }
 `;
 
-const SuccessConfirmButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
+const SuccessConfirmButton = styled(InlineButton)`
   margin-top: 14px;
-  width: 100%;
-  border: none;
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.brand.primary};
-  color: ${({ theme }) => theme.colors.text.textW};
-  padding: 11px 12px;
+  height: 42px;
 `;
 
 const ModalButtonRow = styled.div`
@@ -1368,28 +1335,14 @@ const ModalButtonRow = styled.div`
   gap: 10px;
 `;
 
-const ModalGhostButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text1};
-  padding: 11px 12px;
+const ModalGhostButton = styled(InlineButton)`
+  width: 100%;
+  height: 42px;
 `;
 
-const ModalPrimaryButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  border: none;
-  border-radius: 10px;
-  background: ${({ theme }) => theme.colors.brand.primary};
-  color: ${({ theme }) => theme.colors.text.textW};
-  padding: 11px 12px;
-
-  &:disabled {
-    background: ${({ theme }) => theme.colors.teacherSettings.primaryDisabledBackground};
-    color: ${({ theme }) => theme.colors.teacherSettings.primaryDisabledText};
-    cursor: not-allowed;
-  }
+const ModalPrimaryButton = styled(InlineButton)`
+  width: 100%;
+  height: 42px;
 `;
 
 const WithdrawConfirmButton = styled(ModalPrimaryButton)`

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -9,7 +9,7 @@ import { ROUTES } from '@/constants/routes';
 import { apiClient } from '@/services/http/apiClient';
 import { IcBack, IcSparkles } from '@/icons';
 
-type ThreadStatus = 'processing' | 'done';
+type ThreadStatus = 'processing' | 'done' | 'hold';
 type DetailLoadState = 'loading' | 'error' | 'success';
 
 type ChatRoomDetailData = {
@@ -177,7 +177,13 @@ export const TeacherThreadDetailPage = () => {
         setCounterpartName(payload.counterpartName || '학부모');
         setStudentName(payload.studentName || '학생');
         setIntentLabel(payload.intentLabel || payload.intentLavel || '미분류');
-        setStatus(payload.status === 'DONE' ? 'done' : 'processing');
+        if (payload.status === 'DONE') {
+          setStatus('done');
+        } else if (payload.status === 'HOLD') {
+          setStatus('hold');
+        } else {
+          setStatus('processing');
+        }
         setLoadState('success');
       } catch {
         setLoadState('error');
@@ -194,6 +200,13 @@ export const TeacherThreadDetailPage = () => {
       return {
         label: '처리중',
         tone: 'processing' as StatusTagTone,
+      };
+    }
+
+    if (status === 'hold') {
+      return {
+        label: '보류',
+        tone: 'hold' as StatusTagTone,
       };
     }
 
@@ -285,6 +298,15 @@ export const TeacherThreadDetailPage = () => {
                   }}
                 >
                   완료
+                </StatusMenuItem>
+                <StatusMenuItem
+                  type="button"
+                  onClick={() => {
+                    setStatus('hold');
+                    setIsStatusMenuOpen(false);
+                  }}
+                >
+                  보류
                 </StatusMenuItem>
               </StatusMenu>
             ) : null}
@@ -396,11 +418,12 @@ export const TeacherThreadDetailPage = () => {
 };
 
 const ThreadDetailPageContainer = styled.section`
-  min-height: calc(100vh - 72px);
+  height: 100%;
   background: ${({ theme }) => theme.colors.background.bg2};
   border-top: 1px solid ${({ theme }) => theme.colors.border.border1};
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 `;
 
 const ThreadHeader = styled.header`
@@ -471,21 +494,26 @@ const ThreadBody = styled.div`
   flex: 1;
   display: flex;
   min-height: 0;
+  overflow: hidden;
 `;
 
 const ConversationPanel = styled.section`
   flex: 1;
   min-width: 0;
+  min-height: 0;
   display: flex;
   flex-direction: column;
   border-right: 1px solid ${({ theme }) => theme.colors.border.border1};
+  overflow: hidden;
 `;
 
 const MessageArea = styled.div`
   flex: 1;
+  min-height: 0;
   background: #cdd8d4;
   padding: 16px 14px;
-  overflow: auto;
+  overflow-y: auto;
+  overflow-x: hidden;
   display: flex;
   flex-direction: column;
   gap: 14px;
@@ -584,9 +612,11 @@ const ComposerWrap = styled.div`
 
 const AssistantPanel = styled.aside`
   width: 320px;
+  min-height: 0;
   background: ${({ theme }) => theme.colors.background.bg1};
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 `;
 
 const AssistantHeader = styled.header`

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -112,15 +112,17 @@ export const TeacherThreadDetailPage = () => {
   const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
   const [messageInput, setMessageInput] = useState('');
   const [analysisResult] = useState<AnalysisResult | null>(null);
+  const [analysisErrorMessage, setAnalysisErrorMessage] = useState('');
+  const [isAnalysisRequesting, setIsAnalysisRequesting] = useState(false);
   const [selectedFeedbackScore, setSelectedFeedbackScore] = useState<number | null>(null);
   const [isFeedbackSaved, setIsFeedbackSaved] = useState(false);
   const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState(false);
   const [feedbackErrorMessage, setFeedbackErrorMessage] = useState('');
   const [loadState, setLoadState] = useState<DetailLoadState>('loading');
   const [detailErrorMessage, setDetailErrorMessage] = useState('');
-  const [counterpartName, setCounterpartName] = useState('학부모');
-  const [studentName, setStudentName] = useState('학생');
-  const [intentLabel, setIntentLabel] = useState('미분류');
+  const [counterpartName, setCounterpartName] = useState('');
+  const [studentName, setStudentName] = useState('');
+  const [intentLabel, setIntentLabel] = useState('');
 
   const [messages, setMessages] = useState<MessageItem[]>([]);
   const [messagesError, setMessagesError] = useState('');
@@ -150,9 +152,9 @@ export const TeacherThreadDetailPage = () => {
         throw new Error('채팅방 데이터가 없습니다.');
       }
 
-      setCounterpartName(payload.counterpartName || '학부모');
-      setStudentName(payload.studentName || '학생');
-      setIntentLabel(payload.intentLabel || payload.intentLavel || '미분류');
+      setCounterpartName(payload.counterpartName ?? '');
+      setStudentName(payload.studentName ?? '');
+      setIntentLabel(payload.intentLabel || payload.intentLavel || '');
       if (payload.status === 'DONE') {
         setStatus('done');
       } else if (payload.status === 'HOLD') {
@@ -255,20 +257,38 @@ export const TeacherThreadDetailPage = () => {
 
   const hasMessageInput = messageInput.trim().length > 0;
   const composerActionMode = analysisResult ? 'send' : 'assist';
-  const isComposerActionDisabled = !hasMessageInput;
+  const isComposerActionDisabled = !hasMessageInput || isAnalysisRequesting;
+
+  const requestMessageAnalysis = useCallback(async () => {
+    if (!hasMessageInput || isAnalysisRequesting || analysisResult) {
+      return;
+    }
+
+    try {
+      setIsAnalysisRequesting(true);
+      setAnalysisErrorMessage('');
+
+      return;
+    } catch {
+      setAnalysisErrorMessage('메시지 분석에 실패했어요');
+    } finally {
+      setIsAnalysisRequesting(false);
+    }
+  }, [analysisResult, hasMessageInput, isAnalysisRequesting]);
 
   const handleComposerActionClick = () => {
-    if (!hasMessageInput) {
-      return;
-    }
-
-    if (analysisResult) {
-      return;
-    }
+    void requestMessageAnalysis();
   };
 
   const handleMessageInputChange = (nextValue: string) => {
     setMessageInput(nextValue);
+    if (analysisErrorMessage) {
+      setAnalysisErrorMessage('');
+    }
+  };
+
+  const handleRetryAnalysis = () => {
+    void requestMessageAnalysis();
   };
 
   const handleSelectFeedbackScore = async (score: number) => {
@@ -343,9 +363,9 @@ export const TeacherThreadDetailPage = () => {
         </BackButtonWrap>
 
         <HeaderInfo>
-          <ParentName>{counterpartName}</ParentName>
-          <StudentName>{studentName}</StudentName>
-          <StatusTagButton label={intentLabel} tone="absence" />
+          <ParentName>{counterpartName || '-'}</ParentName>
+          <StudentName>{studentName || '-'}</StudentName>
+          <StatusTagButton label={intentLabel || '-'} tone="absence" />
 
           <StatusDropdownWrap>
             <StatusTagButton
@@ -358,32 +378,32 @@ export const TeacherThreadDetailPage = () => {
             {isStatusMenuOpen ? (
               <StatusMenu>
                 <StatusMenuItem
-                  type="button"
+                  variant="text"
+                  size="M"
+                  label="처리중"
                   onClick={() => {
                     setStatus('processing');
                     setIsStatusMenuOpen(false);
                   }}
-                >
-                  처리중
-                </StatusMenuItem>
+                />
                 <StatusMenuItem
-                  type="button"
+                  variant="text"
+                  size="M"
+                  label="완료"
                   onClick={() => {
                     setStatus('done');
                     setIsStatusMenuOpen(false);
                   }}
-                >
-                  완료
-                </StatusMenuItem>
+                />
                 <StatusMenuItem
-                  type="button"
+                  variant="text"
+                  size="M"
+                  label="보류"
                   onClick={() => {
                     setStatus('hold');
                     setIsStatusMenuOpen(false);
                   }}
-                >
-                  보류
-                </StatusMenuItem>
+                />
               </StatusMenu>
             ) : null}
           </StatusDropdownWrap>
@@ -494,7 +514,7 @@ export const TeacherThreadDetailPage = () => {
             <span>AI 소통 어시스턴트</span>
           </AssistantHeader>
 
-          {!analysisResult ? (
+          {!analysisResult && !analysisErrorMessage ? (
             <AssistantEmpty>
               <IcSparkles />
               <AssistantEmptyTitle>아직 분석할 메시지가 없어요</AssistantEmptyTitle>
@@ -502,6 +522,30 @@ export const TeacherThreadDetailPage = () => {
                 메시지를 작성하면 분쟁 가능성을 살펴보고, 필요한 경우 더 부드러운 답장을 추천드려요.
               </AssistantEmptyText>
             </AssistantEmpty>
+          ) : null}
+
+          {!analysisResult && analysisErrorMessage ? (
+            <AnalysisResultSection>
+              <AnalysisTitle>AI 분쟁 가능성 분석</AnalysisTitle>
+              <AnalysisErrorBanner role="alert">
+                <AnalysisErrorLeft>
+                  <AnalysisErrorIcon>
+                    <IcError />
+                  </AnalysisErrorIcon>
+                  <AnalysisErrorTextWrap>
+                    <AnalysisErrorTitle>{analysisErrorMessage}</AnalysisErrorTitle>
+                    <AnalysisErrorDesc>잠시 후 다시 시도해 주세요.</AnalysisErrorDesc>
+                  </AnalysisErrorTextWrap>
+                </AnalysisErrorLeft>
+                <InlineButton
+                  variant="text"
+                  size="M"
+                  label={isAnalysisRequesting ? '요청 중...' : '다시 시도'}
+                  onClick={handleRetryAnalysis}
+                  disabled={isAnalysisRequesting}
+                />
+              </AnalysisErrorBanner>
+            </AnalysisResultSection>
           ) : null}
 
           {analysisResult ? (
@@ -525,13 +569,14 @@ export const TeacherThreadDetailPage = () => {
                 {[1, 2, 3, 4, 5].map(score => (
                   <ScoreButton
                     key={score}
-                    type="button"
                     $isActive={selectedFeedbackScore === score}
+                    variant={selectedFeedbackScore === score ? 'primary' : 'ghost'}
+                    size="M"
+                    width="40px"
+                    label={String(score)}
                     onClick={() => void handleSelectFeedbackScore(score)}
                     disabled={isFeedbackSubmitting}
-                  >
-                    {score}
-                  </ScoreButton>
+                  />
                 ))}
               </ScoreButtonRow>
               <ScoreLabelRow>
@@ -556,9 +601,13 @@ export const TeacherThreadDetailPage = () => {
                 <RecommendSection>
                   <RecommendTitle>AI 추천 답변</RecommendTitle>
                   <RecommendCard>{analysisResult.recommendedReply}</RecommendCard>
-                  <RecommendApplyButton type="button" onClick={handleApplyRecommendedReply}>
-                    적용하기
-                  </RecommendApplyButton>
+                  <RecommendApplyButton
+                    variant="ghost"
+                    size="M"
+                    width="100%"
+                    label="적용하기"
+                    onClick={handleApplyRecommendedReply}
+                  />
                 </RecommendSection>
               ) : null}
             </AnalysisResultSection>
@@ -630,16 +679,11 @@ const StatusMenu = styled.div`
   z-index: 10;
 `;
 
-const StatusMenuItem = styled.button`
-  ${({ theme }) => theme.fonts.body3};
+const StatusMenuItem = styled(InlineButton)`
   width: 100%;
-  text-align: left;
+  justify-content: flex-start;
+  border-radius: 0;
   padding: 8px 10px;
-  color: ${({ theme }) => theme.colors.text.text2};
-
-  &:hover {
-    background: ${({ theme }) => theme.colors.background.bg4};
-  }
 `;
 
 const ThreadBody = styled.div`
@@ -650,7 +694,7 @@ const ThreadBody = styled.div`
 `;
 
 const ConversationPanel = styled.section`
-  flex: 1;
+  flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
   display: flex;
@@ -662,7 +706,7 @@ const ConversationPanel = styled.section`
 const MessageArea = styled.div`
   flex: 1;
   min-height: 0;
-  background: #cdd8d4;
+  background: ${({ theme }) => theme.colors.reports.previewBackground};
   padding: 16px 14px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -678,7 +722,7 @@ const DetailErrorBox = styled.div`
   align-items: center;
   justify-content: center;
   text-align: center;
-  background: #cdd8d4;
+  background: ${({ theme }) => theme.colors.reports.previewBackground};
 `;
 
 const DetailErrorIcon = styled.span`
@@ -719,8 +763,8 @@ const PartialErrorBanner = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 14px;
-  border: 1px solid #e6bf84;
-  background: #fff7eb;
+  border: 1px solid ${({ theme }) => theme.colors.intent.absenceLate.border};
+  background: ${({ theme }) => theme.colors.intent.absenceLate.background};
   border-radius: 14px;
   padding: 10px 12px;
 `;
@@ -733,7 +777,7 @@ const PartialErrorLeft = styled.div`
 `;
 
 const PartialErrorIcon = styled.span`
-  color: #d48724;
+  color: ${({ theme }) => theme.colors.intent.absenceLate.text};
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -751,13 +795,13 @@ const PartialErrorTextWrap = styled.div`
 const PartialErrorTitle = styled.p`
   ${({ theme }) => theme.fonts.labelXS};
   margin: 0;
-  color: #cf7f14;
+  color: ${({ theme }) => theme.colors.intent.absenceLate.text};
 `;
 
 const PartialErrorDesc = styled.p`
   ${({ theme }) => theme.fonts.caption};
   margin: 4px 0 0;
-  color: #cb9b62;
+  color: ${({ theme }) => theme.colors.intent.absenceLate.text};
 `;
 
 const MessageRow = styled.article<{ $isMine: boolean }>`
@@ -817,7 +861,8 @@ const MessageBubble = styled.div<{ $isMine: boolean }>`
   padding: 16px;
   line-height: 1.45;
   color: ${({ $isMine, theme }) => ($isMine ? theme.colors.text.textW : theme.colors.text.text2)};
-  background: ${({ $isMine }) => ($isMine ? '#56b6a9' : '#f8faf9')};
+  background: ${({ $isMine, theme }) =>
+    $isMine ? theme.colors.brand.primary : theme.colors.background.bg1};
 `;
 
 const UnreadMarker = styled.span`
@@ -835,7 +880,8 @@ const ComposerWrap = styled.div`
 `;
 
 const AssistantPanel = styled.aside`
-  width: 320px;
+  width: clamp(360px, 28vw, 440px);
+  min-width: 360px;
   min-height: 0;
   background: ${({ theme }) => theme.colors.background.bg1};
   display: flex;
@@ -894,6 +940,57 @@ const AnalysisResultSection = styled.div`
   gap: 10px;
 `;
 
+const AnalysisErrorBanner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.reports.modalErrorBorder};
+  border-radius: 16px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  padding: 12px;
+
+  button {
+    flex-shrink: 0;
+    white-space: nowrap;
+  }
+`;
+
+const AnalysisErrorLeft = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+`;
+
+const AnalysisErrorIcon = styled.span`
+  color: ${({ theme }) => theme.colors.semantic.error};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const AnalysisErrorTextWrap = styled.div`
+  min-width: 0;
+`;
+
+const AnalysisErrorTitle = styled.p`
+  ${({ theme }) => theme.fonts.labelS};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.semantic.error};
+`;
+
+const AnalysisErrorDesc = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  margin: 2px 0 0;
+  color: ${({ theme }) => theme.colors.semantic.error};
+`;
+
 const AnalysisTitle = styled.h4`
   ${({ theme }) => theme.fonts.labelS};
   margin: 0;
@@ -901,17 +998,20 @@ const AnalysisTitle = styled.h4`
 `;
 
 const LowRiskCard = styled.div<{ $risk: 'low' | 'high' }>`
-  border: 1px solid #dce5dd;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
   border-radius: 12px;
-  background: ${({ $risk }) => ($risk === 'high' ? '#fff8f8' : '#f8fbf8')};
-  border-color: ${({ $risk }) => ($risk === 'high' ? '#f1d4d4' : '#dce5dd')};
+  background: ${({ $risk, theme }) =>
+    $risk === 'high' ? theme.colors.semantic.errorSoft : theme.colors.semantic.successSoft};
+  border-color: ${({ $risk, theme }) =>
+    $risk === 'high' ? theme.colors.reports.modalErrorBorder : theme.colors.border.border1};
   padding: 12px;
 `;
 
 const LowRiskTitle = styled.p<{ $risk: 'low' | 'high' }>`
   ${({ theme }) => theme.fonts.labelXS};
   margin: 0;
-  color: ${({ $risk }) => ($risk === 'high' ? '#db4545' : '#36a159')};
+  color: ${({ $risk, theme }) =>
+    $risk === 'high' ? theme.colors.semantic.error : theme.colors.semantic.success};
 `;
 
 const LowRiskDescription = styled.p`
@@ -932,23 +1032,10 @@ const ScoreButtonRow = styled.div`
   gap: 8px;
 `;
 
-const ScoreButton = styled.button<{ $isActive: boolean }>`
-  ${({ theme }) => theme.fonts.labelXS};
-  width: 40px;
-  height: 32px;
+const ScoreButton = styled(InlineButton)<{ $isActive: boolean }>`
   border-radius: 8px;
-  border: 1px solid
-    ${({ $isActive, theme }) =>
-      $isActive ? theme.colors.brand.primary : theme.colors.border.border1};
-  background: ${({ $isActive, theme }) =>
-    $isActive ? theme.colors.brand.primary : theme.colors.background.bg1};
-  color: ${({ $isActive, theme }) =>
-    $isActive ? theme.colors.text.textW : theme.colors.text.text2};
-
-  &:disabled {
-    opacity: 0.6;
-    cursor: not-allowed;
-  }
+  padding: 0;
+  min-width: 40px;
 `;
 
 const ScoreLabelRow = styled.div`
@@ -960,22 +1047,22 @@ const ScoreLabelRow = styled.div`
 
 const FeedbackSavedCard = styled.div`
   margin-top: 2px;
-  border: 1px solid #6dbeb3;
+  border: 1px solid ${({ theme }) => theme.colors.threadStatus.processing.border};
   border-radius: 12px;
-  background: #d9f2ee;
+  background: ${({ theme }) => theme.colors.threadStatus.processing.background};
   padding: 10px 12px;
 `;
 
 const FeedbackSavedTitle = styled.p`
   ${({ theme }) => theme.fonts.labelXS};
   margin: 0;
-  color: #2f7e73;
+  color: ${({ theme }) => theme.colors.threadStatus.processing.text};
 `;
 
 const FeedbackSavedText = styled.p`
   ${({ theme }) => theme.fonts.caption};
   margin: 4px 0 0;
-  color: #3f8e83;
+  color: ${({ theme }) => theme.colors.threadStatus.processing.text};
 `;
 
 const FeedbackErrorText = styled.p`
@@ -1006,12 +1093,4 @@ const RecommendCard = styled.div`
   line-height: 1.45;
 `;
 
-const RecommendApplyButton = styled.button`
-  ${({ theme }) => theme.fonts.labelXS};
-  width: 100%;
-  height: 34px;
-  border-radius: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.border.border1};
-  background: ${({ theme }) => theme.colors.background.bg1};
-  color: ${({ theme }) => theme.colors.text.text1};
-`;
+const RecommendApplyButton = styled(InlineButton)``;

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -7,10 +7,11 @@ import { ChatComposer } from '@/components/common/chat/ChatComposer';
 import { StatusTagButton, type StatusTagTone } from '@/components/common/chat/StatusTagButton';
 import { ROUTES } from '@/constants/routes';
 import { apiClient } from '@/services/http/apiClient';
-import { IcBack, IcSparkles } from '@/icons';
+import { IcBack, IcError, IcInfo, IcRefresh, IcSparkles } from '@/icons';
 
 type ThreadStatus = 'processing' | 'done' | 'hold';
 type DetailLoadState = 'loading' | 'error' | 'success';
+type AnalysisRiskLevel = 'LOW' | 'HIGH';
 
 type ChatRoomDetailData = {
   chatRoomId: number;
@@ -47,6 +48,25 @@ type ChatRoomMessagesApiResponse = {
     nextCursor: number | null;
     hasNext: boolean;
   } | null;
+};
+
+type RiskFeedbackPayload = {
+  messageId: number;
+  feedback: 'APPROPRIATE' | 'INAPPROPRIATE';
+};
+
+type RiskFeedbackResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data?: null;
+};
+
+type AnalysisResult = {
+  targetMessageId: number;
+  riskLevel: AnalysisRiskLevel;
+  summary: string;
+  recommendedReply?: string | null;
 };
 
 type MessageItem = {
@@ -91,8 +111,11 @@ export const TeacherThreadDetailPage = () => {
   const [status, setStatus] = useState<ThreadStatus>('processing');
   const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
   const [messageInput, setMessageInput] = useState('');
-  const [isAnalyzing, setIsAnalyzing] = useState(false);
-  const [hasAnalysisResult, setHasAnalysisResult] = useState(false);
+  const [analysisResult] = useState<AnalysisResult | null>(null);
+  const [selectedFeedbackScore, setSelectedFeedbackScore] = useState<number | null>(null);
+  const [isFeedbackSaved, setIsFeedbackSaved] = useState(false);
+  const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState(false);
+  const [feedbackErrorMessage, setFeedbackErrorMessage] = useState('');
   const [loadState, setLoadState] = useState<DetailLoadState>('loading');
   const [detailErrorMessage, setDetailErrorMessage] = useState('');
   const [counterpartName, setCounterpartName] = useState('학부모');
@@ -101,12 +124,48 @@ export const TeacherThreadDetailPage = () => {
 
   const [messages, setMessages] = useState<MessageItem[]>([]);
   const [messagesError, setMessagesError] = useState('');
+  const [messagesPartialError, setMessagesPartialError] = useState('');
   const [isMessagesLoading, setIsMessagesLoading] = useState(false);
   const [isMessagesLoadingMore, setIsMessagesLoadingMore] = useState(false);
   const [messagesNextCursor, setMessagesNextCursor] = useState<number | null>(null);
   const [messagesHasNext, setMessagesHasNext] = useState(false);
 
   const chatRoomId = useMemo(() => Number(threadId), [threadId]);
+
+  const loadChatRoomDetail = useCallback(async () => {
+    if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
+      setLoadState('error');
+      setDetailErrorMessage('대화 정보를 불러올 수 없어요');
+      return;
+    }
+
+    try {
+      setLoadState('loading');
+      setDetailErrorMessage('');
+
+      const { data } = await apiClient.get<ChatRoomDetailResponse>(`/chat-rooms/${chatRoomId}`);
+      const payload = data.data;
+
+      if (!payload) {
+        throw new Error('채팅방 데이터가 없습니다.');
+      }
+
+      setCounterpartName(payload.counterpartName || '학부모');
+      setStudentName(payload.studentName || '학생');
+      setIntentLabel(payload.intentLabel || payload.intentLavel || '미분류');
+      if (payload.status === 'DONE') {
+        setStatus('done');
+      } else if (payload.status === 'HOLD') {
+        setStatus('hold');
+      } else {
+        setStatus('processing');
+      }
+      setLoadState('success');
+    } catch {
+      setLoadState('error');
+      setDetailErrorMessage('대화 정보를 불러올 수 없어요');
+    }
+  }, [chatRoomId]);
 
   const loadMessages = useCallback(
     async ({ cursor, append }: { cursor?: number; append?: boolean } = {}) => {
@@ -142,10 +201,14 @@ export const TeacherThreadDetailPage = () => {
         setMessages(prev => (append ? [...prev, ...mapped] : mapped));
         setMessagesNextCursor(payload.nextCursor);
         setMessagesHasNext(payload.hasNext);
+        setMessagesPartialError('');
       } catch {
-        if (!append) {
+        if (append) {
+          setMessagesPartialError('채팅 내역 일부를 불러오지 못했어요.');
+        } else {
           setMessages([]);
           setMessagesError('메시지를 불러올 수 없어요.');
+          setMessagesPartialError('');
         }
       } finally {
         setIsMessagesLoading(false);
@@ -156,44 +219,9 @@ export const TeacherThreadDetailPage = () => {
   );
 
   useEffect(() => {
-    if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
-      setLoadState('error');
-      setDetailErrorMessage('채팅방 정보를 불러올 수 없어요.');
-      return;
-    }
-
-    const loadChatRoomDetail = async () => {
-      try {
-        setLoadState('loading');
-        setDetailErrorMessage('');
-
-        const { data } = await apiClient.get<ChatRoomDetailResponse>(`/chat-rooms/${chatRoomId}`);
-        const payload = data.data;
-
-        if (!payload) {
-          throw new Error('채팅방 데이터가 없습니다.');
-        }
-
-        setCounterpartName(payload.counterpartName || '학부모');
-        setStudentName(payload.studentName || '학생');
-        setIntentLabel(payload.intentLabel || payload.intentLavel || '미분류');
-        if (payload.status === 'DONE') {
-          setStatus('done');
-        } else if (payload.status === 'HOLD') {
-          setStatus('hold');
-        } else {
-          setStatus('processing');
-        }
-        setLoadState('success');
-      } catch {
-        setLoadState('error');
-        setDetailErrorMessage('채팅방 정보를 불러올 수 없어요.');
-      }
-    };
-
     void loadChatRoomDetail();
     void loadMessages();
-  }, [chatRoomId, loadMessages]);
+  }, [loadChatRoomDetail, loadMessages]);
 
   const statusInfo = useMemo(() => {
     if (status === 'processing') {
@@ -216,34 +244,69 @@ export const TeacherThreadDetailPage = () => {
     };
   }, [status]);
 
+  const feedbackTargetMessageId = useMemo(() => {
+    if (analysisResult?.targetMessageId) {
+      return analysisResult.targetMessageId;
+    }
+
+    const lastMyMessage = [...messages].reverse().find(message => message.isMine);
+    return lastMyMessage?.id ?? messages[0]?.id ?? null;
+  }, [analysisResult, messages]);
+
   const hasMessageInput = messageInput.trim().length > 0;
-  const composerActionMode = hasAnalysisResult ? 'send' : 'assist';
-  const isComposerActionDisabled = !hasMessageInput || isAnalyzing;
+  const composerActionMode = analysisResult ? 'send' : 'assist';
+  const isComposerActionDisabled = !hasMessageInput;
 
   const handleComposerActionClick = () => {
-    if (!hasMessageInput || isAnalyzing) {
+    if (!hasMessageInput) {
       return;
     }
 
-    if (hasAnalysisResult) {
+    if (analysisResult) {
       return;
     }
-
-    setIsAnalyzing(true);
-
-    window.setTimeout(() => {
-      setIsAnalyzing(false);
-      setHasAnalysisResult(true);
-    }, 1200);
   };
 
   const handleMessageInputChange = (nextValue: string) => {
     setMessageInput(nextValue);
+  };
 
-    if (!nextValue.trim()) {
-      setIsAnalyzing(false);
-      setHasAnalysisResult(false);
+  const handleSelectFeedbackScore = async (score: number) => {
+    if (!feedbackTargetMessageId || isFeedbackSubmitting) {
+      return;
     }
+
+    const feedbackValue: RiskFeedbackPayload['feedback'] =
+      score >= 4 ? 'APPROPRIATE' : 'INAPPROPRIATE';
+
+    try {
+      setIsFeedbackSubmitting(true);
+      setFeedbackErrorMessage('');
+
+      await apiClient.post<RiskFeedbackResponse, unknown, RiskFeedbackPayload>(
+        `/risk-feedback/${feedbackTargetMessageId}`,
+        {
+          messageId: feedbackTargetMessageId,
+          feedback: feedbackValue,
+        }
+      );
+
+      setSelectedFeedbackScore(score);
+      setIsFeedbackSaved(true);
+    } catch {
+      setIsFeedbackSaved(false);
+      setFeedbackErrorMessage('피드백 저장에 실패했어요. 다시 시도해주세요.');
+    } finally {
+      setIsFeedbackSubmitting(false);
+    }
+  };
+
+  const handleApplyRecommendedReply = () => {
+    if (!analysisResult?.recommendedReply) {
+      return;
+    }
+
+    setMessageInput(analysisResult.recommendedReply);
   };
 
   const handleLoadMoreMessages = () => {
@@ -252,6 +315,19 @@ export const TeacherThreadDetailPage = () => {
     }
 
     void loadMessages({ cursor: messagesNextCursor, append: true });
+  };
+
+  const handleRetryMissingMessages = () => {
+    if (!messagesHasNext || messagesNextCursor == null || isMessagesLoadingMore) {
+      return;
+    }
+
+    void loadMessages({ cursor: messagesNextCursor, append: true });
+  };
+
+  const handleRetryConversation = async () => {
+    await loadChatRoomDetail();
+    await loadMessages();
   };
 
   return (
@@ -317,7 +393,22 @@ export const TeacherThreadDetailPage = () => {
       <ThreadBody>
         <ConversationPanel>
           {loadState === 'error' ? (
-            <DetailErrorBox>{detailErrorMessage}</DetailErrorBox>
+            <DetailErrorBox>
+              <DetailErrorIcon>
+                <IcError />
+              </DetailErrorIcon>
+              <DetailErrorTitle>
+                {detailErrorMessage || '대화 정보를 불러올 수 없어요'}
+              </DetailErrorTitle>
+              <DetailErrorDescription>잠시 후 다시 시도해주세요.</DetailErrorDescription>
+              <DetailRetryButton
+                variant="primary"
+                size="L"
+                icon={IcRefresh}
+                label="다시 시도"
+                onClick={() => void handleRetryConversation()}
+              />
+            </DetailErrorBox>
           ) : loadState === 'loading' ? (
             <DetailLoadingBox>채팅방 정보를 불러오는 중입니다.</DetailLoadingBox>
           ) : isMessagesLoading ? (
@@ -326,6 +417,29 @@ export const TeacherThreadDetailPage = () => {
             <DetailErrorBox>{messagesError}</DetailErrorBox>
           ) : (
             <MessageArea>
+              {messagesPartialError ? (
+                <PartialErrorBanner role="alert">
+                  <PartialErrorLeft>
+                    <PartialErrorIcon>
+                      <IcInfo />
+                    </PartialErrorIcon>
+                    <PartialErrorTextWrap>
+                      <PartialErrorTitle>채팅 내역을 불러오지 못했어요</PartialErrorTitle>
+                      <PartialErrorDesc>
+                        일부 데이터가 누락되었어요. 채팅 내역을 다시 불러와 주세요.
+                      </PartialErrorDesc>
+                    </PartialErrorTextWrap>
+                  </PartialErrorLeft>
+
+                  <InlineButton
+                    variant="text"
+                    size="M"
+                    label="다시 시도"
+                    onClick={handleRetryMissingMessages}
+                  />
+                </PartialErrorBanner>
+              ) : null}
+
               {messagesHasNext ? (
                 <LoadMoreWrap>
                   <InlineButton
@@ -380,7 +494,7 @@ export const TeacherThreadDetailPage = () => {
             <span>AI 소통 어시스턴트</span>
           </AssistantHeader>
 
-          {!isAnalyzing && !hasAnalysisResult ? (
+          {!analysisResult ? (
             <AssistantEmpty>
               <IcSparkles />
               <AssistantEmptyTitle>아직 분석할 메시지가 없어요</AssistantEmptyTitle>
@@ -390,26 +504,64 @@ export const TeacherThreadDetailPage = () => {
             </AssistantEmpty>
           ) : null}
 
-          {isAnalyzing ? (
-            <AssistantEmpty>
-              <TypingDots>
-                <span />
-                <span />
-                <span />
-              </TypingDots>
-              <AssistantEmptyTitle>메시지를 살펴보고 있어요</AssistantEmptyTitle>
-              <AssistantEmptyText>표현의 톤과 오해 소지를 점검하고 있어요.</AssistantEmptyText>
-            </AssistantEmpty>
-          ) : null}
+          {analysisResult ? (
+            <AnalysisResultSection>
+              <AnalysisTitle>AI 분쟁 가능성 분석</AnalysisTitle>
 
-          {hasAnalysisResult && !isAnalyzing ? (
-            <AssistantEmpty>
-              <RiskChip>분쟁 가능성 낮음</RiskChip>
-              <AssistantEmptyTitle>메시지를 분석했어요</AssistantEmptyTitle>
-              <AssistantEmptyText>
-                현재 문장은 부드럽고 명확해요. 전송 버튼으로 바로 보낼 수 있어요.
-              </AssistantEmptyText>
-            </AssistantEmpty>
+              {analysisResult.riskLevel === 'HIGH' ? (
+                <LowRiskCard $risk="high">
+                  <LowRiskTitle $risk="high">오해가 발생할 수 있는 메시지예요</LowRiskTitle>
+                  <LowRiskDescription>{analysisResult.summary}</LowRiskDescription>
+                </LowRiskCard>
+              ) : (
+                <LowRiskCard $risk="low">
+                  <LowRiskTitle $risk="low">문제 없는 메시지예요</LowRiskTitle>
+                  <LowRiskDescription>{analysisResult.summary}</LowRiskDescription>
+                </LowRiskCard>
+              )}
+
+              <FeedbackTitle>분쟁 가능성 분석 결과가 얼마나 적절했나요?</FeedbackTitle>
+              <ScoreButtonRow>
+                {[1, 2, 3, 4, 5].map(score => (
+                  <ScoreButton
+                    key={score}
+                    type="button"
+                    $isActive={selectedFeedbackScore === score}
+                    onClick={() => void handleSelectFeedbackScore(score)}
+                    disabled={isFeedbackSubmitting}
+                  >
+                    {score}
+                  </ScoreButton>
+                ))}
+              </ScoreButtonRow>
+              <ScoreLabelRow>
+                <span>매우 부적절</span>
+                <span>매우 적절</span>
+              </ScoreLabelRow>
+
+              {isFeedbackSaved ? (
+                <FeedbackSavedCard>
+                  <FeedbackSavedTitle>의견이 반영되었어요</FeedbackSavedTitle>
+                  <FeedbackSavedText>
+                    보내주신 피드백은 분석 품질 개선에 활용돼요.
+                  </FeedbackSavedText>
+                </FeedbackSavedCard>
+              ) : null}
+
+              {feedbackErrorMessage ? (
+                <FeedbackErrorText>{feedbackErrorMessage}</FeedbackErrorText>
+              ) : null}
+
+              {analysisResult.riskLevel === 'HIGH' && analysisResult.recommendedReply ? (
+                <RecommendSection>
+                  <RecommendTitle>AI 추천 답변</RecommendTitle>
+                  <RecommendCard>{analysisResult.recommendedReply}</RecommendCard>
+                  <RecommendApplyButton type="button" onClick={handleApplyRecommendedReply}>
+                    적용하기
+                  </RecommendApplyButton>
+                </RecommendSection>
+              ) : null}
+            </AnalysisResultSection>
           ) : null}
         </AssistantPanel>
       </ThreadBody>
@@ -520,12 +672,38 @@ const MessageArea = styled.div`
 `;
 
 const DetailErrorBox = styled.div`
-  ${({ theme }) => theme.fonts.labelS};
   flex: 1;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  text-align: center;
+  background: #cdd8d4;
+`;
+
+const DetailErrorIcon = styled.span`
   color: ${({ theme }) => theme.colors.semantic.error};
+
+  svg {
+    width: 28px;
+    height: 28px;
+  }
+`;
+
+const DetailErrorTitle = styled.p`
+  ${({ theme }) => theme.fonts.labelM};
+  margin: 8px 0 0;
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const DetailErrorDescription = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  margin: 8px 0 0;
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const DetailRetryButton = styled(InlineButton)`
+  margin-top: 14px;
 `;
 
 const DetailLoadingBox = styled(DetailErrorBox)`
@@ -534,6 +712,52 @@ const DetailLoadingBox = styled(DetailErrorBox)`
 
 const LoadMoreWrap = styled.div`
   align-self: center;
+`;
+
+const PartialErrorBanner = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  border: 1px solid #e6bf84;
+  background: #fff7eb;
+  border-radius: 14px;
+  padding: 10px 12px;
+`;
+
+const PartialErrorLeft = styled.div`
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  min-width: 0;
+`;
+
+const PartialErrorIcon = styled.span`
+  color: #d48724;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    width: 18px;
+    height: 18px;
+  }
+`;
+
+const PartialErrorTextWrap = styled.div`
+  min-width: 0;
+`;
+
+const PartialErrorTitle = styled.p`
+  ${({ theme }) => theme.fonts.labelXS};
+  margin: 0;
+  color: #cf7f14;
+`;
+
+const PartialErrorDesc = styled.p`
+  ${({ theme }) => theme.fonts.caption};
+  margin: 4px 0 0;
+  color: #cb9b62;
 `;
 
 const MessageRow = styled.article<{ $isMine: boolean }>`
@@ -663,25 +887,131 @@ const AssistantEmptyText = styled.p`
   color: ${({ theme }) => theme.colors.text.text4};
 `;
 
-const TypingDots = styled.div`
-  display: inline-flex;
-  align-items: center;
-  gap: 6px;
+const AnalysisResultSection = styled.div`
+  padding: 14px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+`;
 
-  span {
-    width: 8px;
-    height: 8px;
-    border-radius: 999px;
-    background: ${({ theme }) => theme.colors.brand.primary};
-    opacity: 0.8;
+const AnalysisTitle = styled.h4`
+  ${({ theme }) => theme.fonts.labelS};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const LowRiskCard = styled.div<{ $risk: 'low' | 'high' }>`
+  border: 1px solid #dce5dd;
+  border-radius: 12px;
+  background: ${({ $risk }) => ($risk === 'high' ? '#fff8f8' : '#f8fbf8')};
+  border-color: ${({ $risk }) => ($risk === 'high' ? '#f1d4d4' : '#dce5dd')};
+  padding: 12px;
+`;
+
+const LowRiskTitle = styled.p<{ $risk: 'low' | 'high' }>`
+  ${({ theme }) => theme.fonts.labelXS};
+  margin: 0;
+  color: ${({ $risk }) => ($risk === 'high' ? '#db4545' : '#36a159')};
+`;
+
+const LowRiskDescription = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  margin: 8px 0 0;
+  color: ${({ theme }) => theme.colors.text.text2};
+`;
+
+const FeedbackTitle = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const ScoreButtonRow = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const ScoreButton = styled.button<{ $isActive: boolean }>`
+  ${({ theme }) => theme.fonts.labelXS};
+  width: 40px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid
+    ${({ $isActive, theme }) =>
+      $isActive ? theme.colors.brand.primary : theme.colors.border.border1};
+  background: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.brand.primary : theme.colors.background.bg1};
+  color: ${({ $isActive, theme }) =>
+    $isActive ? theme.colors.text.textW : theme.colors.text.text2};
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
   }
 `;
 
-const RiskChip = styled.span`
+const ScoreLabelRow = styled.div`
+  ${({ theme }) => theme.fonts.caption};
+  display: flex;
+  justify-content: space-between;
+  color: ${({ theme }) => theme.colors.text.text4};
+`;
+
+const FeedbackSavedCard = styled.div`
+  margin-top: 2px;
+  border: 1px solid #6dbeb3;
+  border-radius: 12px;
+  background: #d9f2ee;
+  padding: 10px 12px;
+`;
+
+const FeedbackSavedTitle = styled.p`
   ${({ theme }) => theme.fonts.labelXS};
-  border-radius: 999px;
-  border: 1px solid #8fcbc2;
-  background: #e9f7f4;
-  color: #3e8d80;
-  padding: 4px 10px;
+  margin: 0;
+  color: #2f7e73;
+`;
+
+const FeedbackSavedText = styled.p`
+  ${({ theme }) => theme.fonts.caption};
+  margin: 4px 0 0;
+  color: #3f8e83;
+`;
+
+const FeedbackErrorText = styled.p`
+  ${({ theme }) => theme.fonts.caption};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.semantic.error};
+`;
+
+const RecommendSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const RecommendTitle = styled.h5`
+  ${({ theme }) => theme.fonts.labelS};
+  margin: 2px 0 0;
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const RecommendCard = styled.div`
+  ${({ theme }) => theme.fonts.body3};
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text2};
+  padding: 12px;
+  line-height: 1.45;
+`;
+
+const RecommendApplyButton = styled.button`
+  ${({ theme }) => theme.fonts.labelXS};
+  width: 100%;
+  height: 34px;
+  border-radius: 10px;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg1};
+  color: ${({ theme }) => theme.colors.text.text1};
 `;

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -50,6 +50,17 @@ type ChatRoomMessagesApiResponse = {
   } | null;
 };
 
+type MarkMessagesReadResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data?: {
+    chatRoomId: number;
+    unreadCount: number;
+    lastReadAt: string;
+  } | null;
+};
+
 type RiskFeedbackPayload = {
   messageId: number;
   feedback: 'APPROPRIATE' | 'INAPPROPRIATE';
@@ -134,6 +145,18 @@ export const TeacherThreadDetailPage = () => {
 
   const chatRoomId = useMemo(() => Number(threadId), [threadId]);
 
+  const markMessagesAsRead = useCallback(async () => {
+    if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
+      return;
+    }
+
+    try {
+      await apiClient.post<MarkMessagesReadResponse>(`/chat-rooms/${chatRoomId}/read`);
+    } catch {
+      // 읽음 처리는 부가 동작이므로, 실패해도 화면 흐름은 유지합니다.
+    }
+  }, [chatRoomId]);
+
   const loadChatRoomDetail = useCallback(async () => {
     if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
       setLoadState('error');
@@ -204,6 +227,10 @@ export const TeacherThreadDetailPage = () => {
         setMessagesNextCursor(payload.nextCursor);
         setMessagesHasNext(payload.hasNext);
         setMessagesPartialError('');
+
+        if (!append) {
+          void markMessagesAsRead();
+        }
       } catch {
         if (append) {
           setMessagesPartialError('채팅 내역 일부를 불러오지 못했어요.');
@@ -217,7 +244,7 @@ export const TeacherThreadDetailPage = () => {
         setIsMessagesLoadingMore(false);
       }
     },
-    [chatRoomId]
+    [chatRoomId, markMessagesAsRead]
   );
 
   useEffect(() => {

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -61,18 +61,6 @@ type MarkMessagesReadResponse = {
   } | null;
 };
 
-type RiskFeedbackPayload = {
-  messageId: number;
-  feedback: 'APPROPRIATE' | 'INAPPROPRIATE';
-};
-
-type RiskFeedbackResponse = {
-  success: boolean;
-  code: number;
-  message: string;
-  data?: null;
-};
-
 type AnalysisResult = {
   targetMessageId: number;
   riskLevel: AnalysisRiskLevel;
@@ -125,10 +113,6 @@ export const TeacherThreadDetailPage = () => {
   const [analysisResult] = useState<AnalysisResult | null>(null);
   const [analysisErrorMessage, setAnalysisErrorMessage] = useState('');
   const [isAnalysisRequesting, setIsAnalysisRequesting] = useState(false);
-  const [selectedFeedbackScore, setSelectedFeedbackScore] = useState<number | null>(null);
-  const [isFeedbackSaved, setIsFeedbackSaved] = useState(false);
-  const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState(false);
-  const [feedbackErrorMessage, setFeedbackErrorMessage] = useState('');
   const [loadState, setLoadState] = useState<DetailLoadState>('loading');
   const [detailErrorMessage, setDetailErrorMessage] = useState('');
   const [counterpartName, setCounterpartName] = useState('');
@@ -273,15 +257,6 @@ export const TeacherThreadDetailPage = () => {
     };
   }, [status]);
 
-  const feedbackTargetMessageId = useMemo(() => {
-    if (analysisResult?.targetMessageId) {
-      return analysisResult.targetMessageId;
-    }
-
-    const lastMyMessage = [...messages].reverse().find(message => message.isMine);
-    return lastMyMessage?.id ?? messages[0]?.id ?? null;
-  }, [analysisResult, messages]);
-
   const hasMessageInput = messageInput.trim().length > 0;
   const composerActionMode = analysisResult ? 'send' : 'assist';
   const isComposerActionDisabled = !hasMessageInput || isAnalysisRequesting;
@@ -316,36 +291,6 @@ export const TeacherThreadDetailPage = () => {
 
   const handleRetryAnalysis = () => {
     void requestMessageAnalysis();
-  };
-
-  const handleSelectFeedbackScore = async (score: number) => {
-    if (!feedbackTargetMessageId || isFeedbackSubmitting) {
-      return;
-    }
-
-    const feedbackValue: RiskFeedbackPayload['feedback'] =
-      score >= 4 ? 'APPROPRIATE' : 'INAPPROPRIATE';
-
-    try {
-      setIsFeedbackSubmitting(true);
-      setFeedbackErrorMessage('');
-
-      await apiClient.post<RiskFeedbackResponse, unknown, RiskFeedbackPayload>(
-        `/risk-feedback/${feedbackTargetMessageId}`,
-        {
-          messageId: feedbackTargetMessageId,
-          feedback: feedbackValue,
-        }
-      );
-
-      setSelectedFeedbackScore(score);
-      setIsFeedbackSaved(true);
-    } catch {
-      setIsFeedbackSaved(false);
-      setFeedbackErrorMessage('피드백 저장에 실패했어요. 다시 시도해주세요.');
-    } finally {
-      setIsFeedbackSubmitting(false);
-    }
   };
 
   const handleApplyRecommendedReply = () => {
@@ -590,39 +535,6 @@ export const TeacherThreadDetailPage = () => {
                   <LowRiskDescription>{analysisResult.summary}</LowRiskDescription>
                 </LowRiskCard>
               )}
-
-              <FeedbackTitle>분쟁 가능성 분석 결과가 얼마나 적절했나요?</FeedbackTitle>
-              <ScoreButtonRow>
-                {[1, 2, 3, 4, 5].map(score => (
-                  <ScoreButton
-                    key={score}
-                    $isActive={selectedFeedbackScore === score}
-                    variant={selectedFeedbackScore === score ? 'primary' : 'ghost'}
-                    size="M"
-                    width="40px"
-                    label={String(score)}
-                    onClick={() => void handleSelectFeedbackScore(score)}
-                    disabled={isFeedbackSubmitting}
-                  />
-                ))}
-              </ScoreButtonRow>
-              <ScoreLabelRow>
-                <span>매우 부적절</span>
-                <span>매우 적절</span>
-              </ScoreLabelRow>
-
-              {isFeedbackSaved ? (
-                <FeedbackSavedCard>
-                  <FeedbackSavedTitle>의견이 반영되었어요</FeedbackSavedTitle>
-                  <FeedbackSavedText>
-                    보내주신 피드백은 분석 품질 개선에 활용돼요.
-                  </FeedbackSavedText>
-                </FeedbackSavedCard>
-              ) : null}
-
-              {feedbackErrorMessage ? (
-                <FeedbackErrorText>{feedbackErrorMessage}</FeedbackErrorText>
-              ) : null}
 
               {analysisResult.riskLevel === 'HIGH' && analysisResult.recommendedReply ? (
                 <RecommendSection>
@@ -1045,57 +957,6 @@ const LowRiskDescription = styled.p`
   ${({ theme }) => theme.fonts.body3};
   margin: 8px 0 0;
   color: ${({ theme }) => theme.colors.text.text2};
-`;
-
-const FeedbackTitle = styled.p`
-  ${({ theme }) => theme.fonts.body3};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.text.text3};
-`;
-
-const ScoreButtonRow = styled.div`
-  display: flex;
-  align-items: center;
-  gap: 8px;
-`;
-
-const ScoreButton = styled(InlineButton)<{ $isActive: boolean }>`
-  border-radius: 8px;
-  padding: 0;
-  min-width: 40px;
-`;
-
-const ScoreLabelRow = styled.div`
-  ${({ theme }) => theme.fonts.caption};
-  display: flex;
-  justify-content: space-between;
-  color: ${({ theme }) => theme.colors.text.text4};
-`;
-
-const FeedbackSavedCard = styled.div`
-  margin-top: 2px;
-  border: 1px solid ${({ theme }) => theme.colors.threadStatus.processing.border};
-  border-radius: 12px;
-  background: ${({ theme }) => theme.colors.threadStatus.processing.background};
-  padding: 10px 12px;
-`;
-
-const FeedbackSavedTitle = styled.p`
-  ${({ theme }) => theme.fonts.labelXS};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.threadStatus.processing.text};
-`;
-
-const FeedbackSavedText = styled.p`
-  ${({ theme }) => theme.fonts.caption};
-  margin: 4px 0 0;
-  color: ${({ theme }) => theme.colors.threadStatus.processing.text};
-`;
-
-const FeedbackErrorText = styled.p`
-  ${({ theme }) => theme.fonts.caption};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
 `;
 
 const RecommendSection = styled.div`

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -706,7 +706,7 @@ const ConversationPanel = styled.section`
 const MessageArea = styled.div`
   flex: 1;
   min-height: 0;
-  background: ${({ theme }) => theme.colors.reports.previewBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 16px 14px;
   overflow-y: auto;
   overflow-x: hidden;
@@ -722,7 +722,7 @@ const DetailErrorBox = styled.div`
   align-items: center;
   justify-content: center;
   text-align: center;
-  background: ${({ theme }) => theme.colors.reports.previewBackground};
+  background: ${({ theme }) => theme.colors.background.bg4};
 `;
 
 const DetailErrorIcon = styled.span`
@@ -945,7 +945,7 @@ const AnalysisErrorBanner = styled.div`
   align-items: center;
   justify-content: space-between;
   gap: 10px;
-  border: 1px solid ${({ theme }) => theme.colors.reports.modalErrorBorder};
+  border: 1px solid ${({ theme }) => theme.colors.semantic.error};
   border-radius: 16px;
   background: ${({ theme }) => theme.colors.background.bg1};
   padding: 12px;
@@ -1003,7 +1003,7 @@ const LowRiskCard = styled.div<{ $risk: 'low' | 'high' }>`
   background: ${({ $risk, theme }) =>
     $risk === 'high' ? theme.colors.semantic.errorSoft : theme.colors.semantic.successSoft};
   border-color: ${({ $risk, theme }) =>
-    $risk === 'high' ? theme.colors.reports.modalErrorBorder : theme.colors.border.border1};
+    $risk === 'high' ? theme.colors.semantic.error : theme.colors.border.border1};
   padding: 12px;
 `;
 

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -7,9 +7,13 @@ import { ChatComposer } from '@/components/common/chat/ChatComposer';
 import { StatusTagButton, type StatusTagTone } from '@/components/common/chat/StatusTagButton';
 import { ROUTES } from '@/constants/routes';
 import { apiClient } from '@/services/http/apiClient';
+import {
+  mapApiStatusToThreadStatus,
+  useThreadStatusStore,
+  type ThreadStatus,
+} from '@/stores/threadStatusStore';
 import { IcBack, IcError, IcInfo, IcRefresh, IcSparkles } from '@/icons';
 
-type ThreadStatus = 'processing' | 'done' | 'hold';
 type DetailLoadState = 'loading' | 'error' | 'success';
 type AnalysisRiskLevel = 'LOW' | 'HIGH';
 
@@ -128,6 +132,8 @@ export const TeacherThreadDetailPage = () => {
   const [messagesHasNext, setMessagesHasNext] = useState(false);
 
   const chatRoomId = useMemo(() => Number(threadId), [threadId]);
+  const setRoomStatus = useThreadStatusStore(state => state.setRoomStatus);
+  const statusByRoomId = useThreadStatusStore(state => state.statusByRoomId);
 
   const markMessagesAsRead = useCallback(async () => {
     if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
@@ -162,19 +168,19 @@ export const TeacherThreadDetailPage = () => {
       setCounterpartName(payload.counterpartName ?? '');
       setStudentName(payload.studentName ?? '');
       setIntentLabel(payload.intentLabel || payload.intentLavel || '');
-      if (payload.status === 'DONE') {
-        setStatus('done');
-      } else if (payload.status === 'HOLD') {
-        setStatus('hold');
-      } else {
-        setStatus('processing');
+      const mappedStatus = mapApiStatusToThreadStatus(payload.status);
+      const overriddenStatus = statusByRoomId[chatRoomId];
+      const nextStatus = overriddenStatus ?? mappedStatus;
+      setStatus(nextStatus);
+      if (!overriddenStatus) {
+        setRoomStatus(chatRoomId, mappedStatus);
       }
       setLoadState('success');
     } catch {
       setLoadState('error');
       setDetailErrorMessage('대화 정보를 불러올 수 없어요');
     }
-  }, [chatRoomId]);
+  }, [chatRoomId, setRoomStatus, statusByRoomId]);
 
   const loadMessages = useCallback(
     async ({ cursor, append }: { cursor?: number; append?: boolean } = {}) => {
@@ -355,6 +361,7 @@ export const TeacherThreadDetailPage = () => {
                   label="처리중"
                   onClick={() => {
                     setStatus('processing');
+                    setRoomStatus(chatRoomId, 'processing');
                     setIsStatusMenuOpen(false);
                   }}
                 />
@@ -364,6 +371,7 @@ export const TeacherThreadDetailPage = () => {
                   label="완료"
                   onClick={() => {
                     setStatus('done');
+                    setRoomStatus(chatRoomId, 'done');
                     setIsStatusMenuOpen(false);
                   }}
                 />
@@ -373,6 +381,7 @@ export const TeacherThreadDetailPage = () => {
                   label="보류"
                   onClick={() => {
                     setStatus('hold');
+                    setRoomStatus(chatRoomId, 'hold');
                     setIsStatusMenuOpen(false);
                   }}
                 />

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -1,11 +1,657 @@
+﻿import { useCallback, useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
+import { useNavigate, useParams } from 'react-router-dom';
+import { IconButton } from '@/components/common/IconButton';
+import { InlineButton } from '@/components/common/InlineButton';
+import { ChatComposer } from '@/components/common/chat/ChatComposer';
+import { StatusTagButton, type StatusTagTone } from '@/components/common/chat/StatusTagButton';
+import { ROUTES } from '@/constants/routes';
+import { apiClient } from '@/services/http/apiClient';
+import { IcBack, IcSparkles } from '@/icons';
 
-export const TeacherThreadDetailPage = () => {
-  return <ThreadDetailPageContainer title="채팅방 페이지" />;
+type ThreadStatus = 'processing' | 'done';
+type DetailLoadState = 'loading' | 'error' | 'success';
+
+type ChatRoomDetailData = {
+  chatRoomId: number;
+  counterpartName: string;
+  studentName: string;
+  intentLabel?: string;
+  intentLavel?: string;
+  status: string;
 };
 
-const ThreadDetailPageContainer = styled.div`
+type ChatRoomDetailResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data?: ChatRoomDetailData | null;
+};
+
+type ChatRoomMessageResponse = {
+  messageId: number;
+  isMine: boolean;
+  senderName: string;
+  senderRole: string;
+  content: string;
+  createdAt: string;
+};
+
+type ChatRoomMessagesApiResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  data?: {
+    chatRoomId: number;
+    messages: ChatRoomMessageResponse[];
+    nextCursor: number | null;
+    hasNext: boolean;
+  } | null;
+};
+
+type MessageItem = {
+  id: number;
+  senderName: string;
+  sentAt: string;
+  content: string;
+  isMine: boolean;
+  unreadCount?: number;
+};
+
+const formatMessageTime = (value: string) => {
+  if (!value) return '-';
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+
+  const year = parsed.getFullYear();
+  const month = `${parsed.getMonth() + 1}`.padStart(2, '0');
+  const day = `${parsed.getDate()}`.padStart(2, '0');
+  const hour24 = parsed.getHours();
+  const minute = `${parsed.getMinutes()}`.padStart(2, '0');
+  const period = hour24 >= 12 ? '오후' : '오전';
+  const hour12 = hour24 % 12 || 12;
+
+  return `${year}-${month}-${day} ${period} ${hour12}:${minute}`;
+};
+
+const toMessageItem = (message: ChatRoomMessageResponse): MessageItem => {
+  return {
+    id: message.messageId,
+    senderName: message.senderName || '-',
+    sentAt: formatMessageTime(message.createdAt),
+    content: message.content || '-',
+    isMine: message.isMine,
+  };
+};
+
+export const TeacherThreadDetailPage = () => {
+  const navigate = useNavigate();
+  const { threadId } = useParams();
+  const [status, setStatus] = useState<ThreadStatus>('processing');
+  const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
+  const [messageInput, setMessageInput] = useState('');
+  const [isAnalyzing, setIsAnalyzing] = useState(false);
+  const [hasAnalysisResult, setHasAnalysisResult] = useState(false);
+  const [loadState, setLoadState] = useState<DetailLoadState>('loading');
+  const [detailErrorMessage, setDetailErrorMessage] = useState('');
+  const [counterpartName, setCounterpartName] = useState('학부모');
+  const [studentName, setStudentName] = useState('학생');
+  const [intentLabel, setIntentLabel] = useState('미분류');
+
+  const [messages, setMessages] = useState<MessageItem[]>([]);
+  const [messagesError, setMessagesError] = useState('');
+  const [isMessagesLoading, setIsMessagesLoading] = useState(false);
+  const [isMessagesLoadingMore, setIsMessagesLoadingMore] = useState(false);
+  const [messagesNextCursor, setMessagesNextCursor] = useState<number | null>(null);
+  const [messagesHasNext, setMessagesHasNext] = useState(false);
+
+  const chatRoomId = useMemo(() => Number(threadId), [threadId]);
+
+  const loadMessages = useCallback(
+    async ({ cursor, append }: { cursor?: number; append?: boolean } = {}) => {
+      if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
+        return;
+      }
+
+      try {
+        if (append) {
+          setIsMessagesLoadingMore(true);
+        } else {
+          setIsMessagesLoading(true);
+          setMessagesError('');
+        }
+
+        const { data } = await apiClient.get<ChatRoomMessagesApiResponse>(
+          `/chat-rooms/${chatRoomId}/messages`,
+          {
+            params: {
+              size: 20,
+              ...(cursor != null ? { cursor } : {}),
+            },
+          }
+        );
+
+        const payload = data.data;
+        if (!payload) {
+          throw new Error('메시지 데이터가 없습니다.');
+        }
+
+        const mapped = payload.messages.map(toMessageItem);
+
+        setMessages(prev => (append ? [...prev, ...mapped] : mapped));
+        setMessagesNextCursor(payload.nextCursor);
+        setMessagesHasNext(payload.hasNext);
+      } catch {
+        if (!append) {
+          setMessages([]);
+          setMessagesError('메시지를 불러올 수 없어요.');
+        }
+      } finally {
+        setIsMessagesLoading(false);
+        setIsMessagesLoadingMore(false);
+      }
+    },
+    [chatRoomId]
+  );
+
+  useEffect(() => {
+    if (!Number.isFinite(chatRoomId) || chatRoomId <= 0) {
+      setLoadState('error');
+      setDetailErrorMessage('채팅방 정보를 불러올 수 없어요.');
+      return;
+    }
+
+    const loadChatRoomDetail = async () => {
+      try {
+        setLoadState('loading');
+        setDetailErrorMessage('');
+
+        const { data } = await apiClient.get<ChatRoomDetailResponse>(`/chat-rooms/${chatRoomId}`);
+        const payload = data.data;
+
+        if (!payload) {
+          throw new Error('채팅방 데이터가 없습니다.');
+        }
+
+        setCounterpartName(payload.counterpartName || '학부모');
+        setStudentName(payload.studentName || '학생');
+        setIntentLabel(payload.intentLabel || payload.intentLavel || '미분류');
+        setStatus(payload.status === 'DONE' ? 'done' : 'processing');
+        setLoadState('success');
+      } catch {
+        setLoadState('error');
+        setDetailErrorMessage('채팅방 정보를 불러올 수 없어요.');
+      }
+    };
+
+    void loadChatRoomDetail();
+    void loadMessages();
+  }, [chatRoomId, loadMessages]);
+
+  const statusInfo = useMemo(() => {
+    if (status === 'processing') {
+      return {
+        label: '처리중',
+        tone: 'processing' as StatusTagTone,
+      };
+    }
+
+    return {
+      label: '완료',
+      tone: 'done' as StatusTagTone,
+    };
+  }, [status]);
+
+  const hasMessageInput = messageInput.trim().length > 0;
+  const composerActionMode = hasAnalysisResult ? 'send' : 'assist';
+  const isComposerActionDisabled = !hasMessageInput || isAnalyzing;
+
+  const handleComposerActionClick = () => {
+    if (!hasMessageInput || isAnalyzing) {
+      return;
+    }
+
+    if (hasAnalysisResult) {
+      return;
+    }
+
+    setIsAnalyzing(true);
+
+    window.setTimeout(() => {
+      setIsAnalyzing(false);
+      setHasAnalysisResult(true);
+    }, 1200);
+  };
+
+  const handleMessageInputChange = (nextValue: string) => {
+    setMessageInput(nextValue);
+
+    if (!nextValue.trim()) {
+      setIsAnalyzing(false);
+      setHasAnalysisResult(false);
+    }
+  };
+
+  const handleLoadMoreMessages = () => {
+    if (!messagesHasNext || messagesNextCursor == null || isMessagesLoadingMore) {
+      return;
+    }
+
+    void loadMessages({ cursor: messagesNextCursor, append: true });
+  };
+
+  return (
+    <ThreadDetailPageContainer>
+      <ThreadHeader>
+        <BackButtonWrap>
+          <IconButton
+            icon={IcBack}
+            variant="plain"
+            accessibilityLabel="수신함으로 이동"
+            onClick={() => navigate(ROUTES.teacherThreadList)}
+          />
+        </BackButtonWrap>
+
+        <HeaderInfo>
+          <ParentName>{counterpartName}</ParentName>
+          <StudentName>{studentName}</StudentName>
+          <StatusTagButton label={intentLabel} tone="absence" />
+
+          <StatusDropdownWrap>
+            <StatusTagButton
+              label={statusInfo.label}
+              tone={statusInfo.tone}
+              isDropdown
+              onClick={() => setIsStatusMenuOpen(prev => !prev)}
+            />
+
+            {isStatusMenuOpen ? (
+              <StatusMenu>
+                <StatusMenuItem
+                  type="button"
+                  onClick={() => {
+                    setStatus('processing');
+                    setIsStatusMenuOpen(false);
+                  }}
+                >
+                  처리중
+                </StatusMenuItem>
+                <StatusMenuItem
+                  type="button"
+                  onClick={() => {
+                    setStatus('done');
+                    setIsStatusMenuOpen(false);
+                  }}
+                >
+                  완료
+                </StatusMenuItem>
+              </StatusMenu>
+            ) : null}
+          </StatusDropdownWrap>
+        </HeaderInfo>
+      </ThreadHeader>
+
+      <ThreadBody>
+        <ConversationPanel>
+          {loadState === 'error' ? (
+            <DetailErrorBox>{detailErrorMessage}</DetailErrorBox>
+          ) : loadState === 'loading' ? (
+            <DetailLoadingBox>채팅방 정보를 불러오는 중입니다.</DetailLoadingBox>
+          ) : isMessagesLoading ? (
+            <DetailLoadingBox>메시지를 불러오는 중입니다.</DetailLoadingBox>
+          ) : messagesError ? (
+            <DetailErrorBox>{messagesError}</DetailErrorBox>
+          ) : (
+            <MessageArea>
+              {messagesHasNext ? (
+                <LoadMoreWrap>
+                  <InlineButton
+                    variant="ghost"
+                    size="M"
+                    label={isMessagesLoadingMore ? '불러오는 중...' : '이전 메시지 더보기'}
+                    onClick={handleLoadMoreMessages}
+                    disabled={isMessagesLoadingMore}
+                  />
+                </LoadMoreWrap>
+              ) : null}
+
+              {messages.map(message => (
+                <MessageRow key={message.id} $isMine={message.isMine}>
+                  {!message.isMine ? (
+                    <IncomingMeta>
+                      <Avatar>{message.senderName.charAt(0)}</Avatar>
+                      <IncomingInfo>
+                        <SenderName>{message.senderName}</SenderName>
+                        <MessageTime>{message.sentAt}</MessageTime>
+                      </IncomingInfo>
+                    </IncomingMeta>
+                  ) : (
+                    <OutgoingTime>{message.sentAt}</OutgoingTime>
+                  )}
+
+                  <BubbleWrap $isMine={message.isMine}>
+                    <MessageBubble $isMine={message.isMine}>{message.content}</MessageBubble>
+                    {message.isMine && message.unreadCount ? (
+                      <UnreadMarker>{message.unreadCount}</UnreadMarker>
+                    ) : null}
+                  </BubbleWrap>
+                </MessageRow>
+              ))}
+            </MessageArea>
+          )}
+
+          <ComposerWrap>
+            <ChatComposer
+              value={messageInput}
+              onChange={handleMessageInputChange}
+              actionMode={composerActionMode}
+              isActionDisabled={isComposerActionDisabled}
+              onActionClick={handleComposerActionClick}
+            />
+          </ComposerWrap>
+        </ConversationPanel>
+
+        <AssistantPanel>
+          <AssistantHeader>
+            <IcSparkles />
+            <span>AI 소통 어시스턴트</span>
+          </AssistantHeader>
+
+          {!isAnalyzing && !hasAnalysisResult ? (
+            <AssistantEmpty>
+              <IcSparkles />
+              <AssistantEmptyTitle>아직 분석할 메시지가 없어요</AssistantEmptyTitle>
+              <AssistantEmptyText>
+                메시지를 작성하면 분쟁 가능성을 살펴보고, 필요한 경우 더 부드러운 답장을 추천드려요.
+              </AssistantEmptyText>
+            </AssistantEmpty>
+          ) : null}
+
+          {isAnalyzing ? (
+            <AssistantEmpty>
+              <TypingDots>
+                <span />
+                <span />
+                <span />
+              </TypingDots>
+              <AssistantEmptyTitle>메시지를 살펴보고 있어요</AssistantEmptyTitle>
+              <AssistantEmptyText>표현의 톤과 오해 소지를 점검하고 있어요.</AssistantEmptyText>
+            </AssistantEmpty>
+          ) : null}
+
+          {hasAnalysisResult && !isAnalyzing ? (
+            <AssistantEmpty>
+              <RiskChip>분쟁 가능성 낮음</RiskChip>
+              <AssistantEmptyTitle>메시지를 분석했어요</AssistantEmptyTitle>
+              <AssistantEmptyText>
+                현재 문장은 부드럽고 명확해요. 전송 버튼으로 바로 보낼 수 있어요.
+              </AssistantEmptyText>
+            </AssistantEmpty>
+          ) : null}
+        </AssistantPanel>
+      </ThreadBody>
+    </ThreadDetailPageContainer>
+  );
+};
+
+const ThreadDetailPageContainer = styled.section`
+  min-height: calc(100vh - 72px);
+  background: ${({ theme }) => theme.colors.background.bg2};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.border1};
   display: flex;
   flex-direction: column;
-  padding: 24px;
+`;
+
+const ThreadHeader = styled.header`
+  height: 84px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 0 20px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
+  background: ${({ theme }) => theme.colors.background.bg1};
+`;
+
+const BackButtonWrap = styled.div`
+  button {
+    width: 32px;
+    height: 32px;
+  }
+`;
+
+const HeaderInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  position: relative;
+`;
+
+const ParentName = styled.h2`
+  ${({ theme }) => theme.fonts.titleM};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const StudentName = styled.span`
+  ${({ theme }) => theme.fonts.labelM};
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const StatusDropdownWrap = styled.div`
+  position: relative;
+`;
+
+const StatusMenu = styled.div`
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  min-width: 92px;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 10px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  box-shadow: ${({ theme }) => theme.colors.shadow.card};
+  overflow: hidden;
+  z-index: 10;
+`;
+
+const StatusMenuItem = styled.button`
+  ${({ theme }) => theme.fonts.body3};
+  width: 100%;
+  text-align: left;
+  padding: 8px 10px;
+  color: ${({ theme }) => theme.colors.text.text2};
+
+  &:hover {
+    background: ${({ theme }) => theme.colors.background.bg4};
+  }
+`;
+
+const ThreadBody = styled.div`
+  flex: 1;
+  display: flex;
+  min-height: 0;
+`;
+
+const ConversationPanel = styled.section`
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid ${({ theme }) => theme.colors.border.border1};
+`;
+
+const MessageArea = styled.div`
+  flex: 1;
+  background: #cdd8d4;
+  padding: 16px 14px;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;
+
+const DetailErrorBox = styled.div`
+  ${({ theme }) => theme.fonts.labelS};
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: ${({ theme }) => theme.colors.semantic.error};
+`;
+
+const DetailLoadingBox = styled(DetailErrorBox)`
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const LoadMoreWrap = styled.div`
+  align-self: center;
+`;
+
+const MessageRow = styled.article<{ $isMine: boolean }>`
+  display: flex;
+  flex-direction: column;
+  align-items: ${({ $isMine }) => ($isMine ? 'flex-end' : 'flex-start')};
+  gap: 8px;
+`;
+
+const IncomingMeta = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 10px;
+`;
+
+const Avatar = styled.span`
+  ${({ theme }) => theme.fonts.labelXS};
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.background.bg4};
+  color: ${({ theme }) => theme.colors.brand.dark};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const IncomingInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const SenderName = styled.span`
+  ${({ theme }) => theme.fonts.labelXS};
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const MessageTime = styled.span`
+  ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme }) => theme.colors.text.text4};
+`;
+
+const OutgoingTime = styled(MessageTime)`
+  margin-right: 4px;
+`;
+
+const BubbleWrap = styled.div<{ $isMine: boolean }>`
+  position: relative;
+  max-width: min(62%, 650px);
+  ${({ $isMine }) => ($isMine ? 'margin-right: 0;' : '')}
+`;
+
+const MessageBubble = styled.div<{ $isMine: boolean }>`
+  ${({ theme }) => theme.fonts.body2};
+  border-radius: 16px;
+  padding: 16px;
+  line-height: 1.45;
+  color: ${({ $isMine, theme }) => ($isMine ? theme.colors.text.textW : theme.colors.text.text2)};
+  background: ${({ $isMine }) => ($isMine ? '#56b6a9' : '#f8faf9')};
+`;
+
+const UnreadMarker = styled.span`
+  ${({ theme }) => theme.fonts.labelXS};
+  position: absolute;
+  left: -14px;
+  bottom: 4px;
+  color: ${({ theme }) => theme.colors.brand.dark};
+`;
+
+const ComposerWrap = styled.div`
+  padding: 12px;
+  background: ${({ theme }) => theme.colors.background.bg2};
+  border-top: 1px solid ${({ theme }) => theme.colors.border.border1};
+`;
+
+const AssistantPanel = styled.aside`
+  width: 320px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  display: flex;
+  flex-direction: column;
+`;
+
+const AssistantHeader = styled.header`
+  ${({ theme }) => theme.fonts.labelM};
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: ${({ theme }) => theme.colors.brand.dark};
+  padding: 16px 14px;
+  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+`;
+
+const AssistantEmpty = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  text-align: center;
+  padding: 20px;
+  color: ${({ theme }) => theme.colors.text.text4};
+
+  svg {
+    width: 20px;
+    height: 20px;
+  }
+`;
+
+const AssistantEmptyTitle = styled.p`
+  ${({ theme }) => theme.fonts.labelS};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const AssistantEmptyText = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  margin: 0;
+  color: ${({ theme }) => theme.colors.text.text4};
+`;
+
+const TypingDots = styled.div`
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+
+  span {
+    width: 8px;
+    height: 8px;
+    border-radius: 999px;
+    background: ${({ theme }) => theme.colors.brand.primary};
+    opacity: 0.8;
+  }
+`;
+
+const RiskChip = styled.span`
+  ${({ theme }) => theme.fonts.labelXS};
+  border-radius: 999px;
+  border: 1px solid #8fcbc2;
+  background: #e9f7f4;
+  color: #3e8d80;
+  padding: 4px 10px;
 `;

--- a/src/pages/teacher/threadList/TeacherThreadListPage.tsx
+++ b/src/pages/teacher/threadList/TeacherThreadListPage.tsx
@@ -323,28 +323,28 @@ const Tag = styled.span<{ tone: IntentTone }>`
   padding: 4px 10px;
   border: 1px solid
     ${({ tone, theme }) => {
-      if (tone === 'counsel') return '#8CB6FF';
-      if (tone === 'progress') return '#8FCBC2';
-      if (tone === 'inquiry') return '#8AC78A';
-      if (tone === 'absence') return '#F8C088';
-      if (tone === 'request') return '#C49BFF';
+      if (tone === 'counsel') return theme.colors.intent.counseling.border;
+      if (tone === 'progress') return theme.colors.threadStatus.processing.border;
+      if (tone === 'inquiry') return theme.colors.intent.inquiry.border;
+      if (tone === 'absence') return theme.colors.intent.absenceLate.border;
+      if (tone === 'request') return theme.colors.intent.request.border;
       return theme.colors.border.border2;
     }};
   color: ${({ tone, theme }) => {
-    if (tone === 'counsel') return '#4E76CC';
-    if (tone === 'progress') return '#3E8D80';
-    if (tone === 'inquiry') return '#3A8C3F';
-    if (tone === 'absence') return '#C56A17';
-    if (tone === 'request') return '#7D46D6';
+    if (tone === 'counsel') return theme.colors.intent.counseling.text;
+    if (tone === 'progress') return theme.colors.threadStatus.processing.text;
+    if (tone === 'inquiry') return theme.colors.intent.inquiry.text;
+    if (tone === 'absence') return theme.colors.intent.absenceLate.text;
+    if (tone === 'request') return theme.colors.intent.request.text;
     return theme.colors.text.text3;
   }};
-  background: ${({ tone }) => {
-    if (tone === 'counsel') return '#EDF4FF';
-    if (tone === 'progress') return '#E9F7F4';
-    if (tone === 'inquiry') return '#EDFAEE';
-    if (tone === 'absence') return '#FFF5E8';
-    if (tone === 'request') return '#F4EDFF';
-    return '#F5F6F8';
+  background: ${({ tone, theme }) => {
+    if (tone === 'counsel') return theme.colors.intent.counseling.background;
+    if (tone === 'progress') return theme.colors.threadStatus.processing.background;
+    if (tone === 'inquiry') return theme.colors.intent.inquiry.background;
+    if (tone === 'absence') return theme.colors.intent.absenceLate.background;
+    if (tone === 'request') return theme.colors.intent.request.background;
+    return theme.colors.background.bg3;
   }};
 `;
 

--- a/src/pages/teacher/threadList/TeacherThreadListPage.tsx
+++ b/src/pages/teacher/threadList/TeacherThreadListPage.tsx
@@ -1,7 +1,9 @@
 ﻿import { useEffect, useMemo, useState } from 'react';
 import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
 import { InlineButton } from '@/components/common/InlineButton';
 import { SectionEmptyState } from '@/components/common/SectionEmptyState';
+import { ROUTES } from '@/constants/routes';
 import { apiClient } from '@/services/http/apiClient';
 import { IcChat, IcError, IcRefresh } from '@/icons';
 
@@ -34,6 +36,10 @@ type ChatRoomsApiResponse = {
   code: number;
   message: string;
   content?: ChatRoomResponse[];
+  data?: {
+    content?: ChatRoomResponse[];
+    items?: ChatRoomResponse[];
+  } | null;
   nextCursor?: number | null;
   size?: number;
   hasNext?: boolean;
@@ -100,6 +106,7 @@ const toThreadRoomItem = (room: ChatRoomResponse): ThreadRoomItem => {
 };
 
 export const TeacherThreadListPage = () => {
+  const navigate = useNavigate();
   const [rooms, setRooms] = useState<ThreadRoomItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
@@ -113,7 +120,7 @@ export const TeacherThreadListPage = () => {
         params: { page: 0, size: 20 },
       });
 
-      const list = data.content ?? [];
+      const list = data.data?.content ?? [];
       setRooms(list.map(toThreadRoomItem));
     } catch {
       setRooms([]);
@@ -142,7 +149,13 @@ export const TeacherThreadListPage = () => {
         {loadState === 'success' ? (
           <ThreadList>
             {rooms.map(room => (
-              <ThreadCard key={room.id} type="button">
+              <ThreadCard
+                key={room.id}
+                type="button"
+                onClick={() =>
+                  navigate(ROUTES.teacherThreadDetail.replace(':threadId', String(room.id)))
+                }
+              >
                 <Avatar>{room.studentName.charAt(0)}</Avatar>
                 <CardBody>
                   <TopRow>

--- a/src/pages/teacher/threadList/TeacherThreadListPage.tsx
+++ b/src/pages/teacher/threadList/TeacherThreadListPage.tsx
@@ -2,9 +2,16 @@
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import { InlineButton } from '@/components/common/InlineButton';
+import { StatusTagButton, type StatusTagTone } from '@/components/common/chat/StatusTagButton';
 import { SectionEmptyState } from '@/components/common/SectionEmptyState';
 import { ROUTES } from '@/constants/routes';
 import { apiClient } from '@/services/http/apiClient';
+import {
+  mapApiStatusToThreadStatus,
+  toThreadStatusLabel,
+  useThreadStatusStore,
+  type ThreadStatus,
+} from '@/stores/threadStatusStore';
 import { IcChat, IcError, IcRefresh } from '@/icons';
 
 type InboxLoadState = 'loading' | 'error' | 'empty' | 'success';
@@ -17,7 +24,8 @@ type ThreadRoomItem = {
   preview: string;
   timeText: string;
   unreadCount: number;
-  tags: Array<{ label: string; tone: IntentTone }>;
+  intentTag: { label: string; tone: IntentTone };
+  status: ThreadStatus;
 };
 
 type ChatRoomResponse = {
@@ -89,7 +97,6 @@ const formatTimeText = (value: string) => {
 
 const toThreadRoomItem = (room: ChatRoomResponse): ThreadRoomItem => {
   const intentLabel = room.intentLabel?.trim() || '미분류';
-  const statusLabel = room.status?.trim() || '상태없음';
 
   return {
     id: room.chatRoomId,
@@ -98,15 +105,14 @@ const toThreadRoomItem = (room: ChatRoomResponse): ThreadRoomItem => {
     preview: room.lastMessage || '-',
     timeText: formatTimeText(room.lastMessageAt),
     unreadCount: room.unreadCount ?? 0,
-    tags: [
-      { label: intentLabel, tone: resolveTagTone(intentLabel) },
-      { label: statusLabel, tone: resolveTagTone(statusLabel) },
-    ],
+    intentTag: { label: intentLabel, tone: resolveTagTone(intentLabel) },
+    status: mapApiStatusToThreadStatus(room.status),
   };
 };
 
 export const TeacherThreadListPage = () => {
   const navigate = useNavigate();
+  const statusByRoomId = useThreadStatusStore(state => state.statusByRoomId);
   const [rooms, setRooms] = useState<ThreadRoomItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [errorMessage, setErrorMessage] = useState('');
@@ -168,11 +174,11 @@ export const TeacherThreadListPage = () => {
                   <PreviewText>{room.preview}</PreviewText>
                   <BottomRow>
                     <TagWrap>
-                      {room.tags.map(tag => (
-                        <Tag key={`${room.id}-${tag.label}`} tone={tag.tone}>
-                          {tag.label}
-                        </Tag>
-                      ))}
+                      <Tag tone={room.intentTag.tone}>{room.intentTag.label}</Tag>
+                      <StatusTagButton
+                        label={toThreadStatusLabel(statusByRoomId[room.id] ?? room.status)}
+                        tone={resolveThreadStatusTone(statusByRoomId[room.id] ?? room.status)}
+                      />
                     </TagWrap>
                     {room.unreadCount > 0 ? <UnreadBadge>{room.unreadCount}</UnreadBadge> : null}
                   </BottomRow>
@@ -212,6 +218,12 @@ export const TeacherThreadListPage = () => {
       ) : null}
     </ThreadListPageContainer>
   );
+};
+
+const resolveThreadStatusTone = (status: ThreadStatus): StatusTagTone => {
+  if (status === 'done') return 'done';
+  if (status === 'hold') return 'hold';
+  return 'processing';
 };
 
 const ThreadListPageContainer = styled.section`

--- a/src/pages/teacher/threadList/TeacherThreadListPage.tsx
+++ b/src/pages/teacher/threadList/TeacherThreadListPage.tsx
@@ -1,32 +1,199 @@
-﻿import styled from '@emotion/styled';
+﻿import { useEffect, useMemo, useState } from 'react';
+import styled from '@emotion/styled';
 import { InlineButton } from '@/components/common/InlineButton';
-import { IcError, IcRefresh } from '@/icons';
+import { SectionEmptyState } from '@/components/common/SectionEmptyState';
+import { apiClient } from '@/services/http/apiClient';
+import { IcChat, IcError, IcRefresh } from '@/icons';
 
-type InboxLoadState = 'error' | 'empty' | 'success';
+type InboxLoadState = 'loading' | 'error' | 'empty' | 'success';
+type IntentTone = 'counsel' | 'progress' | 'inquiry' | 'absence' | 'request' | 'done';
+
+type ThreadRoomItem = {
+  id: number;
+  counterpartName: string;
+  studentName: string;
+  preview: string;
+  timeText: string;
+  unreadCount: number;
+  tags: Array<{ label: string; tone: IntentTone }>;
+};
+
+type ChatRoomResponse = {
+  chatRoomId: number;
+  counterpartName: string;
+  studentName: string;
+  lastMessage: string;
+  lastMessageAt: string;
+  unreadCount: number;
+  status: string;
+  intentLabel: string;
+};
+
+type ChatRoomsApiResponse = {
+  success: boolean;
+  code: number;
+  message: string;
+  content?: ChatRoomResponse[];
+  nextCursor?: number | null;
+  size?: number;
+  hasNext?: boolean;
+};
+
+const resolveTagTone = (label: string): IntentTone => {
+  const value = label.trim().toLowerCase();
+
+  if (value.includes('상담') || value.includes('counsel')) return 'counsel';
+  if (value.includes('처리') || value.includes('진행') || value.includes('process'))
+    return 'progress';
+  if (value.includes('문의') || value.includes('question') || value.includes('inquiry'))
+    return 'inquiry';
+  if (value.includes('결석') || value.includes('지각') || value.includes('absence'))
+    return 'absence';
+  if (value.includes('요청') || value.includes('request')) return 'request';
+
+  return 'done';
+};
+
+const formatTimeText = (value: string) => {
+  if (!value) return '-';
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+
+  const now = new Date();
+  const isSameDay =
+    parsed.getFullYear() === now.getFullYear() &&
+    parsed.getMonth() === now.getMonth() &&
+    parsed.getDate() === now.getDate();
+
+  if (isSameDay) {
+    const hour24 = parsed.getHours();
+    const minute = `${parsed.getMinutes()}`.padStart(2, '0');
+    const period = hour24 >= 12 ? '오후' : '오전';
+    const hour12 = hour24 % 12 || 12;
+
+    return `${period} ${hour12}:${minute}`;
+  }
+
+  const year = parsed.getFullYear();
+  const month = `${parsed.getMonth() + 1}`.padStart(2, '0');
+  const day = `${parsed.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const toThreadRoomItem = (room: ChatRoomResponse): ThreadRoomItem => {
+  const intentLabel = room.intentLabel?.trim() || '미분류';
+  const statusLabel = room.status?.trim() || '상태없음';
+
+  return {
+    id: room.chatRoomId,
+    counterpartName: room.counterpartName || '-',
+    studentName: room.studentName || '-',
+    preview: room.lastMessage || '-',
+    timeText: formatTimeText(room.lastMessageAt),
+    unreadCount: room.unreadCount ?? 0,
+    tags: [
+      { label: intentLabel, tone: resolveTagTone(intentLabel) },
+      { label: statusLabel, tone: resolveTagTone(statusLabel) },
+    ],
+  };
+};
 
 export const TeacherThreadListPage = () => {
-  const loadState: InboxLoadState = 'error';
+  const [rooms, setRooms] = useState<ThreadRoomItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState('');
 
-  const handleRetry = () => {
-    // TODO: 대화 목록 조회 API 연결 후 재시도 로직 연동
+  const loadRooms = async () => {
+    try {
+      setIsLoading(true);
+      setErrorMessage('');
+
+      const { data } = await apiClient.get<ChatRoomsApiResponse>('/chat-rooms', {
+        params: { page: 0, size: 20 },
+      });
+
+      const list = data.content ?? [];
+      setRooms(list.map(toThreadRoomItem));
+    } catch {
+      setRooms([]);
+      setErrorMessage('대화 목록을 불러올 수 없어요.');
+    } finally {
+      setIsLoading(false);
+    }
   };
+
+  useEffect(() => {
+    void loadRooms();
+  }, []);
+
+  const loadState = useMemo<InboxLoadState>(() => {
+    if (isLoading) return 'loading';
+    if (errorMessage) return 'error';
+    if (rooms.length === 0) return 'empty';
+    return 'success';
+  }, [errorMessage, isLoading, rooms.length]);
 
   return (
     <ThreadListPageContainer>
+      <InboxListSection>
+        {loadState === 'loading' ? <StatusText>대화 목록을 불러오는 중입니다.</StatusText> : null}
+
+        {loadState === 'success' ? (
+          <ThreadList>
+            {rooms.map(room => (
+              <ThreadCard key={room.id} type="button">
+                <Avatar>{room.studentName.charAt(0)}</Avatar>
+                <CardBody>
+                  <TopRow>
+                    <NameWrap>
+                      <ParentName>{room.counterpartName}</ParentName>
+                      <StudentName>{room.studentName}</StudentName>
+                    </NameWrap>
+                    <TimeText>{room.timeText}</TimeText>
+                  </TopRow>
+                  <PreviewText>{room.preview}</PreviewText>
+                  <BottomRow>
+                    <TagWrap>
+                      {room.tags.map(tag => (
+                        <Tag key={`${room.id}-${tag.label}`} tone={tag.tone}>
+                          {tag.label}
+                        </Tag>
+                      ))}
+                    </TagWrap>
+                    {room.unreadCount > 0 ? <UnreadBadge>{room.unreadCount}</UnreadBadge> : null}
+                  </BottomRow>
+                </CardBody>
+              </ThreadCard>
+            ))}
+          </ThreadList>
+        ) : null}
+
+        {loadState === 'empty' ? (
+          <EmptySection>
+            <SectionEmptyState
+              icon={IcChat}
+              title="표시할 대화 목록이 없어요"
+              description="새 메시지가 오면 이곳에 채팅방이 표시됩니다."
+            />
+          </EmptySection>
+        ) : null}
+      </InboxListSection>
+
       {loadState === 'error' ? (
         <ErrorStateSection>
           <ErrorIconWrap>
             <IcError />
           </ErrorIconWrap>
           <ErrorTitle>대화 목록을 불러올 수 없어요</ErrorTitle>
-          <ErrorDescription>잠시 후 다시 시도해 주세요.</ErrorDescription>
+          <ErrorDescription>잠시 후 다시 시도해주세요.</ErrorDescription>
           <RetryButton
             type="button"
             variant="primary"
             size="L"
             icon={IcRefresh}
             label="다시 시도"
-            onClick={handleRetry}
+            onClick={() => void loadRooms()}
           />
         </ErrorStateSection>
       ) : null}
@@ -37,16 +204,160 @@ export const TeacherThreadListPage = () => {
 const ThreadListPageContainer = styled.section`
   min-height: calc(100vh - 72px);
   background: ${({ theme }) => theme.colors.background.bg2};
+`;
+
+const InboxListSection = styled.div`
+  width: 100%;
+  padding: 24px 24px 0;
+`;
+
+const StatusText = styled.p`
+  ${({ theme }) => theme.fonts.body2};
+  margin: 12px 0 0;
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const ThreadList = styled.div`
+  margin-top: 20px;
   display: flex;
+  flex-direction: column;
+  gap: 14px;
+`;
+
+const ThreadCard = styled.button`
+  width: 100%;
+  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border-radius: 12px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  padding: 16px;
+  display: flex;
+  gap: 14px;
+  text-align: left;
+`;
+
+const Avatar = styled.span`
+  ${({ theme }) => theme.fonts.labelS};
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.background.bg4};
+  color: ${({ theme }) => theme.colors.brand.dark};
+  display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 24px;
+  flex-shrink: 0;
+`;
+
+const CardBody = styled.div`
+  flex: 1;
+  min-width: 0;
+`;
+
+const TopRow = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const NameWrap = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+const ParentName = styled.strong`
+  ${({ theme }) => theme.fonts.labelM};
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const StudentName = styled.span`
+  ${({ theme }) => theme.fonts.body3};
+  color: ${({ theme }) => theme.colors.text.text4};
+`;
+
+const TimeText = styled.span`
+  ${({ theme }) => theme.fonts.body3};
+  color: ${({ theme }) => theme.colors.text.text4};
+`;
+
+const PreviewText = styled.p`
+  ${({ theme }) => theme.fonts.body2};
+  margin: 10px 0 0;
+  color: ${({ theme }) => theme.colors.text.text3};
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
+const BottomRow = styled.div`
+  margin-top: 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+`;
+
+const TagWrap = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+`;
+
+const Tag = styled.span<{ tone: IntentTone }>`
+  ${({ theme }) => theme.fonts.labelXS};
+  border-radius: 999px;
+  padding: 4px 10px;
+  border: 1px solid
+    ${({ tone, theme }) => {
+      if (tone === 'counsel') return '#8CB6FF';
+      if (tone === 'progress') return '#8FCBC2';
+      if (tone === 'inquiry') return '#8AC78A';
+      if (tone === 'absence') return '#F8C088';
+      if (tone === 'request') return '#C49BFF';
+      return theme.colors.border.border2;
+    }};
+  color: ${({ tone, theme }) => {
+    if (tone === 'counsel') return '#4E76CC';
+    if (tone === 'progress') return '#3E8D80';
+    if (tone === 'inquiry') return '#3A8C3F';
+    if (tone === 'absence') return '#C56A17';
+    if (tone === 'request') return '#7D46D6';
+    return theme.colors.text.text3;
+  }};
+  background: ${({ tone }) => {
+    if (tone === 'counsel') return '#EDF4FF';
+    if (tone === 'progress') return '#E9F7F4';
+    if (tone === 'inquiry') return '#EDFAEE';
+    if (tone === 'absence') return '#FFF5E8';
+    if (tone === 'request') return '#F4EDFF';
+    return '#F5F6F8';
+  }};
+`;
+
+const UnreadBadge = styled.span`
+  ${({ theme }) => theme.fonts.labelS};
+  min-width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.brand.primary};
+  color: ${({ theme }) => theme.colors.text.textW};
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0 8px;
+`;
+
+const EmptySection = styled.div`
+  min-height: calc(100vh - 180px);
 `;
 
 const ErrorStateSection = styled.div`
+  min-height: calc(100vh - 240px);
   display: flex;
   flex-direction: column;
   align-items: center;
+  justify-content: center;
   text-align: center;
 `;
 
@@ -54,8 +365,8 @@ const ErrorIconWrap = styled.span`
   color: ${({ theme }) => theme.colors.semantic.error};
 
   svg {
-    width: 32px;
-    height: 32px;
+    width: 28px;
+    height: 28px;
   }
 `;
 

--- a/src/stores/threadStatusStore.ts
+++ b/src/stores/threadStatusStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+export type ThreadStatus = 'processing' | 'done' | 'hold';
+
+type ThreadStatusState = {
+  statusByRoomId: Record<number, ThreadStatus>;
+  setRoomStatus: (roomId: number, status: ThreadStatus) => void;
+};
+
+export const mapApiStatusToThreadStatus = (status?: string | null): ThreadStatus => {
+  if (status === 'DONE') return 'done';
+  if (status === 'HOLD') return 'hold';
+  return 'processing';
+};
+
+export const toThreadStatusLabel = (status: ThreadStatus): '처리중' | '완료' | '보류' => {
+  if (status === 'done') return '완료';
+  if (status === 'hold') return '보류';
+  return '처리중';
+};
+
+export const useThreadStatusStore = create<ThreadStatusState>()(
+  persist(
+    set => ({
+      statusByRoomId: {},
+      setRoomStatus: (roomId, status) => {
+        set(state => ({
+          statusByRoomId: {
+            ...state.statusByRoomId,
+            [roomId]: status,
+          },
+        }));
+      },
+    }),
+    {
+      name: 'softy-thread-status',
+    }
+  )
+);

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -119,24 +119,6 @@ export const colors = {
     neutral50: '#F7F7F7',
     neutral0: '#FFFFFF',
   },
-  teacherSettings: {
-    avatarBackground: '#D6F3EE',
-    workdayRowBackground: '#F7F8F8',
-    toggleOffBackground: '#E5E7E9',
-    toggleThumbOffBackground: '#F3F4F5',
-    inputDisabledBackground: '#F4F5F6',
-    classCodeBadgeBorder: '#CCEEE8',
-    classCodeBadgeBackground: '#E7F8F5',
-    modalIconBackground: '#E7F8F5',
-    confirmIconBackground: '#FDF7E8',
-    confirmIconColor: '#E59B2D',
-    confirmSummaryBorder: '#D2EBE6',
-    confirmSummaryBackground: '#EAF6F3',
-    confirmErrorBorder: '#FF8E96',
-    confirmErrorBackground: '#FFF2F3',
-    primaryDisabledBackground: '#DBDEE2',
-    primaryDisabledText: '#8F949D',
-  },
 } as const;
 
 export type ColorsType = typeof colors;

--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -42,8 +42,7 @@ export const colors = {
     errorSoft: '#FAE3E2',
   },
   overlay: {
-    dim1: 'rgba(0, 0, 0, 0.42)',
-    dim2: 'rgba(0, 0, 0, 0.45)',
+    dim: 'rgba(0, 0, 0, 0.5)',
   },
   shadow: {
     modal: '0 12px 22px rgba(0, 0, 0, 0.25)',
@@ -52,15 +51,6 @@ export const colors = {
     dialog: '0 20px 48px rgba(0, 0, 0, 0.18)',
     toast: '0 8px 20px rgba(0, 0, 0, 0.08)',
     toastHover: '0 10px 22px rgba(0, 0, 0, 0.15)',
-  },
-  reports: {
-    toastErrorBorder: '#FF7F89',
-    toastErrorBackground: '#FFF4F5',
-    previewBackground: '#DBE7E3',
-    senderAvatarBackground: '#B8EADD',
-    modalErrorBorder: '#FF6B77',
-    modalErrorBackground: '#FFF5F6',
-    modalErrorText: '#EB4955',
   },
   chart: {
     recommendationUsedAsIs: '#55B5A6',


### PR DESCRIPTION
## #️⃣ Issue Number

#30

## 📝 요약(Summary)

수신함 상세 UI 개선 및 채팅방/메시지 API 연동
메시지 조회 시 읽음 처리 API 연동
상태 드롭다운 옵션 및 상태 관리 정리
채팅 입력창 엔터 줄바꿈 지원
설정 페이지 진입 후 사이드바 탭 전환 멈춤 버그 수정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항
교사 채팅 관련 페이지/컴포넌트 업데이트
API 연동 및 응답 매핑 정리(채팅방, 메시지, 읽음 처리)
상태 태그/드롭다운 및 전역 상태 스토어(threadStatusStore) 정리
공통 컴포넌트(Dialog, ChatComposer, StatusTagButton) 개선
디자인 토큰(styles/colors.ts) 및 오버레이/리포트 색상 체계 통합
AppLayout의 setHeaderActions 안정화로 설정 페이지 이후 탭 전환 멈춤 문제 해결

## 📷 Screenshots or Video
<img width="2559" height="1402" alt="스크린샷 2026-05-04 133310" src="https://github.com/user-attachments/assets/67942782-6ffc-47ea-a705-6c0cb2f30806" />
<img width="2559" height="1396" alt="스크린샷 2026-05-04 133342" src="https://github.com/user-attachments/assets/1c74e058-1451-4f72-9448-48ca7c8fc09d" />
<img width="307" height="407" alt="스크린샷 2026-05-04 133442" src="https://github.com/user-attachments/assets/e654626f-7a93-4987-88ef-6c999ec82ff8" />
<img width="301" height="398" alt="스크린샷 2026-05-04 133450" src="https://github.com/user-attachments/assets/c7774213-fd2f-40ae-aa71-05f9f9b7d726" />
