### PR TITLE
[FEAT] 관리자 대시보드 PDF 리포트 현황 및 AI 평가 진행 상태 개선 #33

### DIFF
--- a/src/components/admin/aiModel/ModelPerformanceSection.tsx
+++ b/src/components/admin/aiModel/ModelPerformanceSection.tsx
@@ -1,4 +1,5 @@
 import styled from '@emotion/styled';
+import { useEffect, useState } from 'react';
 import { SectionCard, SectionCardContent } from '@/components/common/SectionCard';
 import { KpiCard } from '@/components/common/KpiCard';
 import { PerformanceChart } from './PerformanceChart';
@@ -8,11 +9,46 @@ import { InlineButton } from '@/components/common/InlineButton';
 import { Alert } from '@/components/common/Alert';
 import { Loader } from '@/components/common/Loader';
 import { SectionEmptyState } from '@/components/common/SectionEmptyState';
+import { ProgressBar } from '@/components/admin/aiModel/ProgressBar';
 import { IcDashboard } from '@/icons';
 
+const PROGRESS_VISIBLE_DELAY = 700;
+
 export const ModelPerformanceSection = () => {
-  const { evaluation, isInProgress, isLoading, isError, onRerun, isRerunning, rerunError } =
-    useModelEvaluation();
+  const {
+    evaluation,
+    progressPercent,
+    isInProgress,
+    isCompleted,
+    isFailed,
+    isLoading,
+    isError,
+    onRerun,
+    isRerunning,
+    rerunError,
+  } = useModelEvaluation();
+
+  const [shouldShowProgress, setShouldShowProgress] = useState(false);
+
+  const isProgressPending = isRerunning || isInProgress;
+  const chartData = isCompleted && evaluation ? getPerformanceChartData(evaluation) : [];
+
+  useEffect(() => {
+    if (!isProgressPending) {
+      const timerId = window.setTimeout(() => {
+        setShouldShowProgress(false);
+      }, 0);
+      return () => window.clearTimeout(timerId);
+    }
+
+    const timerId = window.setTimeout(() => {
+      setShouldShowProgress(true);
+    }, PROGRESS_VISIBLE_DELAY);
+
+    return () => {
+      window.clearTimeout(timerId);
+    };
+  }, [isProgressPending]);
 
   const headerAction = (
     <InlineButton
@@ -24,7 +60,9 @@ export const ModelPerformanceSection = () => {
     />
   );
 
-  if (isLoading) return <Loader />;
+  if (isLoading) {
+    return <Loader />;
+  }
 
   if (isError && !evaluation) {
     return (
@@ -36,7 +74,7 @@ export const ModelPerformanceSection = () => {
     );
   }
 
-  if (!evaluation && !isInProgress) {
+  if (!evaluation && !isProgressPending && !isFailed) {
     return (
       <SectionCard title="성능 평가" headerAction={headerAction}>
         <SectionCardContent>
@@ -50,31 +88,46 @@ export const ModelPerformanceSection = () => {
     );
   }
 
-  const chartData = evaluation ? getPerformanceChartData(evaluation) : [];
-
   return (
     <SectionCard title="성능 평가" headerAction={headerAction}>
-      <SectionCardContent>
-        {isInProgress && (
-          <Alert
-            variant="success"
-            title="성능 평가를 진행 중이에요"
-            description="평가가 완료되면 최신 성능 지표를 확인할 수 있어요."
-          />
-        )}
+      {(shouldShowProgress || isFailed || (rerunError && !isProgressPending)) && (
+        <SectionCardContent>
+          <StatusContainer>
+            {shouldShowProgress && (
+              <ProgressContainer>
+                <Alert
+                  variant="success"
+                  title="성능 평가를 진행 중이에요"
+                  description="평가가 완료되면 최신 성능 지표를 확인할 수 있어요."
+                />
+                <ProgressBar label="진행률" value={progressPercent} />
+              </ProgressContainer>
+            )}
 
-        {rerunError && !isInProgress && (
-          <Alert title="성능 평가를 시작하지 못했어요" description="잠시 후 다시 시도해주세요." />
-        )}
-      </SectionCardContent>
+            {isFailed && !isProgressPending && (
+              <Alert
+                title="성능 평가에 실패했어요"
+                description="평가를 다시 실행하거나 잠시 후 다시 시도해주세요."
+              />
+            )}
 
-      {evaluation && (
+            {rerunError && !isProgressPending && (
+              <Alert
+                title="성능 평가를 시작하지 못했어요"
+                description="잠시 후 다시 시도해주세요."
+              />
+            )}
+          </StatusContainer>
+        </SectionCardContent>
+      )}
+
+      {isCompleted && evaluation && (
         <>
           <SectionCardContent>
             <KpiGrid>
-              <KpiCard title="Precision" value={(evaluation.precision * 100).toFixed(2) + '%'} />
-              <KpiCard title="Recall" value={(evaluation.recall * 100).toFixed(2) + '%'} />
-              <KpiCard title="F1-score" value={(evaluation.f1Score * 100).toFixed(2) + '%'} />
+              <KpiCard title="Precision" value={`${(evaluation.precision * 100).toFixed(2)}%`} />
+              <KpiCard title="Recall" value={`${(evaluation.recall * 100).toFixed(2)}%`} />
+              <KpiCard title="F1-score" value={`${(evaluation.f1Score * 100).toFixed(2)}%`} />
             </KpiGrid>
           </SectionCardContent>
 
@@ -86,6 +139,18 @@ export const ModelPerformanceSection = () => {
     </SectionCard>
   );
 };
+
+const StatusContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
+
+const ProgressContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+`;
 
 const KpiGrid = styled.div`
   display: grid;

--- a/src/components/admin/aiModel/ProgressBar.tsx
+++ b/src/components/admin/aiModel/ProgressBar.tsx
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+
+type ProgressBarProps = {
+  value: number;
+  label?: string;
+  valueLabel?: string;
+};
+
+const getSafeProgressValue = (value: number) => {
+  if (!Number.isFinite(value)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, value));
+};
+
+export const ProgressBar = ({ value, label = '진행률', valueLabel }: ProgressBarProps) => {
+  const safeValue = getSafeProgressValue(value);
+  const displayValue = valueLabel ?? `${safeValue}%`;
+
+  return (
+    <ProgressBarContainer>
+      <ProgressMeta>
+        <ProgressLabel>{label}</ProgressLabel>
+        <ProgressValue>{displayValue}</ProgressValue>
+      </ProgressMeta>
+
+      <ProgressTrack
+        role="progressbar"
+        aria-label={label}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={safeValue}
+      >
+        <ProgressIndicator $value={safeValue} />
+      </ProgressTrack>
+    </ProgressBarContainer>
+  );
+};
+
+const ProgressBarContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+const ProgressMeta = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const ProgressLabel = styled.span`
+  ${({ theme }) => theme.fonts.body3};
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const ProgressValue = styled.span`
+  ${({ theme }) => theme.fonts.labelXS};
+  color: ${({ theme }) => theme.colors.text.text1};
+`;
+
+const ProgressTrack = styled.div`
+  overflow: hidden;
+  width: 100%;
+  height: 8px;
+  border-radius: 999px;
+  background: ${({ theme }) => theme.colors.background.bg3};
+`;
+
+const ProgressIndicator = styled.div<{ $value: number }>`
+  width: ${({ $value }) => `${$value}%`};
+  height: 100%;
+  border-radius: inherit;
+  background: ${({ theme }) => theme.colors.brand.primary};
+  transition: width 0.3s ease;
+`;

--- a/src/components/admin/dashboard/PdfReportPanel.tsx
+++ b/src/components/admin/dashboard/PdfReportPanel.tsx
@@ -51,60 +51,39 @@ export const PdfReportPanel = ({ data, isLoading, isError, onRetry }: PdfReportP
         <KpiCard title="PDF 리포트 생성 수 합계" value={`${data.totalPdfCount}건`} />
       </KpiGrid>
 
-      <PdfContentGrid>
-        <SectionCard title="교사별 PDF 생성 수">
-          <PdfChartScrollArea $height={chartHeight} $isScrollable={isChartScrollable}>
-            <PdfChartInner $height={calculatedChartHeight}>
-              <ResponsiveContainer width="100%" height={calculatedChartHeight}>
-                <BarChart
-                  data={chartData}
-                  layout="vertical"
-                  margin={{ top: 16, right: 20, left: 20, bottom: 16 }}
-                >
-                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-                  <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
-                  <YAxis
-                    dataKey="teacherName"
-                    type="category"
-                    width={68}
-                    tickLine={false}
-                    axisLine={false}
-                    tick={{ fontSize: 12 }}
-                  />
-                  <Tooltip
-                    formatter={(value: ValueType | undefined) => [`${value}건`, 'PDF 생성 수']}
-                  />
-                  <Bar
-                    dataKey="pdfCount"
-                    barSize={24}
-                    fill={chartColors.pdfReport.primary}
-                    radius={[0, 8, 8, 0]}
-                  />
-                </BarChart>
-              </ResponsiveContainer>
-            </PdfChartInner>
-          </PdfChartScrollArea>
-        </SectionCard>
-
-        <SectionCard title="교사별 상세 목록">
-          <PdfTable>
-            <thead>
-              <tr>
-                <PdfTableHeader>교사명</PdfTableHeader>
-                <PdfTableHeader $align="right">PDF 생성 수</PdfTableHeader>
-              </tr>
-            </thead>
-            <tbody>
-              {sortedPdfList.map(item => (
-                <tr key={item.teacherId}>
-                  <PdfTableCell>{item.teacherName}</PdfTableCell>
-                  <PdfTableCell $align="right">{item.pdfCount}</PdfTableCell>
-                </tr>
-              ))}
-            </tbody>
-          </PdfTable>
-        </SectionCard>
-      </PdfContentGrid>
+      <SectionCard title="교사별 PDF 생성 수">
+        <PdfChartScrollArea $height={chartHeight} $isScrollable={isChartScrollable}>
+          <PdfChartInner $height={calculatedChartHeight}>
+            <ResponsiveContainer width="100%" height={calculatedChartHeight}>
+              <BarChart
+                data={chartData}
+                layout="vertical"
+                margin={{ top: 16, right: 20, left: 20, bottom: 16 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+                <YAxis
+                  dataKey="teacherName"
+                  type="category"
+                  width={68}
+                  tickLine={false}
+                  axisLine={false}
+                  tick={{ fontSize: 12 }}
+                />
+                <Tooltip
+                  formatter={(value: ValueType | undefined) => [`${value}건`, 'PDF 생성 수']}
+                />
+                <Bar
+                  dataKey="pdfCount"
+                  barSize={24}
+                  fill={chartColors.pdfReport.primary}
+                  radius={[0, 8, 8, 0]}
+                />
+              </BarChart>
+            </ResponsiveContainer>
+          </PdfChartInner>
+        </PdfChartScrollArea>
+      </SectionCard>
     </PdfReportPanelContainer>
   );
 };
@@ -133,16 +112,6 @@ const KpiGrid = styled.div`
   }
 `;
 
-const PdfContentGrid = styled.div`
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 20px;
-
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
-  }
-`;
-
 const PdfChartScrollArea = styled.div<{ $height: number; $isScrollable: boolean }>`
   width: 100%;
   height: ${({ $height }) => `${$height}px`};
@@ -157,25 +126,4 @@ const PdfChartInner = styled.div<{ $height: number }>`
   .recharts-wrapper *:focus {
     outline: none;
   }
-`;
-
-const PdfTable = styled.table`
-  width: 100%;
-  border-collapse: collapse;
-`;
-
-const PdfTableHeader = styled.th<{ $align?: 'left' | 'right' }>`
-  ${({ theme }) => theme.fonts.labelS};
-  padding: 12px 20px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
-  text-align: ${({ $align = 'left' }) => $align};
-  color: ${({ theme }) => theme.colors.text.text1};
-`;
-
-const PdfTableCell = styled.td<{ $align?: 'left' | 'right' }>`
-  ${({ theme }) => theme.fonts.body3};
-  padding: 16px 20px;
-  border-bottom: 1px solid ${({ theme }) => theme.colors.border.border1};
-  text-align: ${({ $align = 'left' }) => $align};
-  color: ${({ theme }) => theme.colors.text.text1};
 `;

--- a/src/components/admin/dashboard/PdfReportPanel.tsx
+++ b/src/components/admin/dashboard/PdfReportPanel.tsx
@@ -5,7 +5,6 @@ import { SectionErrorState } from '@/components/common/SectionErrorState';
 import { SectionEmptyState } from '@/components/common/SectionEmptyState';
 import { KpiCard } from '@/components/common/KpiCard';
 import { SectionCard } from '@/components/common/SectionCard';
-import { getPdfChartData } from '@/features/admin/dashboard/lib/dashboardChartData';
 import type { PdfStatistics } from '@/features/admin/dashboard/types/dashboard';
 import type { ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import { chartColors } from '@/constants/chartColors';
@@ -36,7 +35,12 @@ export const PdfReportPanel = ({ data, isLoading, isError, onRetry }: PdfReportP
   }
 
   const sortedPdfList = [...data.list].sort((left, right) => right.pdfCount - left.pdfCount);
-  const chartData = getPdfChartData(sortedPdfList);
+
+  const chartData = sortedPdfList.map((teacher, index) => ({
+    chartId: `${teacher.teacherId}-${teacher.teacherName}-${index}`,
+    teacherName: teacher.teacherName,
+    pdfCount: teacher.pdfCount,
+  }));
 
   const calculatedChartHeight = Math.max(
     chartData.length * PDF_CHART_ROW_HEIGHT,
@@ -54,23 +58,30 @@ export const PdfReportPanel = ({ data, isLoading, isError, onRetry }: PdfReportP
       <SectionCard title="교사별 PDF 생성 수">
         <PdfChartScrollArea $height={chartHeight} $isScrollable={isChartScrollable}>
           <PdfChartInner $height={calculatedChartHeight}>
-            <ResponsiveContainer width="100%" height={calculatedChartHeight}>
+            <ResponsiveContainer width="100%" height="100%">
               <BarChart
                 data={chartData}
                 layout="vertical"
                 margin={{ top: 16, right: 20, left: 20, bottom: 16 }}
               >
                 <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-                <XAxis type="number" allowDecimals={false} tick={{ fontSize: 12 }} />
+                <XAxis
+                  type="number"
+                  allowDecimals={false}
+                  domain={[0, 'dataMax']}
+                  tick={{ fontSize: 12 }}
+                />
                 <YAxis
-                  dataKey="teacherName"
+                  dataKey="chartId"
                   type="category"
                   width={68}
                   tickLine={false}
                   axisLine={false}
                   tick={{ fontSize: 12 }}
+                  tickFormatter={(_, index) => chartData[index]?.teacherName ?? ''}
                 />
                 <Tooltip
+                  labelFormatter={(_, payload) => payload?.[0]?.payload?.teacherName ?? ''}
                   formatter={(value: ValueType | undefined) => [`${value}건`, 'PDF 생성 수']}
                 />
                 <Bar

--- a/src/components/common/SectionCard.tsx
+++ b/src/components/common/SectionCard.tsx
@@ -32,6 +32,7 @@ const SectionCardContainer = styled.section`
   display: flex;
   min-width: 0;
   flex-direction: column;
+  border: 1px solid ${({ theme }) => theme.colors.border.border2};
   border-radius: 10px;
   background: ${({ theme }) => theme.colors.background.bg1};
 `;

--- a/src/features/admin/aiModel/hooks/useModelEvaluation.ts
+++ b/src/features/admin/aiModel/hooks/useModelEvaluation.ts
@@ -9,16 +9,26 @@ import {
 import type { LatestModelEvaluation } from '@/services/admin/aiModelApi';
 import { aiModelQueryKeys } from '@/features/admin/aiModel/constants/aiModelQueryKeys';
 
+const EVALUATION_REFETCH_INTERVAL = 1000;
+
 const isInProgressStatus = (status?: LatestModelEvaluation['status'] | null) => {
   return status === 'queued' || status === 'running';
+};
+
+const getSafeProgressPercent = (progressPercent?: number | null) => {
+  if (typeof progressPercent !== 'number' || !Number.isFinite(progressPercent)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, progressPercent));
 };
 
 export const useModelEvaluation = () => {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
 
-  const prevStatusRef = useRef<LatestModelEvaluation['status'] | null>(null);
-  const isRerunTriggeredRef = useRef(false);
+  const isWaitingRerunCompletionRef = useRef(false);
+  const rerunBaseEvaluationIdRef = useRef<string | null>(null);
 
   const {
     data: latestModelInfo,
@@ -35,7 +45,7 @@ export const useModelEvaluation = () => {
     refetchInterval: query => {
       const status = query.state.data?.status;
 
-      return isInProgressStatus(status) ? 3000 : false;
+      return isInProgressStatus(status) ? EVALUATION_REFETCH_INTERVAL : false;
     },
   });
 
@@ -44,19 +54,25 @@ export const useModelEvaluation = () => {
   const isInProgress = isInProgressStatus(status);
   const isCompleted = status === 'completed';
   const isFailed = status === 'failed';
+  const progressPercent = getSafeProgressPercent(evaluation?.progressPercent);
 
   useEffect(() => {
+    const evaluationId = evaluation?.evaluationId;
+
     if (
-      isRerunTriggeredRef.current &&
-      prevStatusRef.current !== 'completed' &&
-      status === 'completed'
+      isWaitingRerunCompletionRef.current &&
+      status === 'completed' &&
+      evaluationId &&
+      evaluationId !== rerunBaseEvaluationIdRef.current
     ) {
       showToast('성능 평가가 완료되었어요', 'success');
-      isRerunTriggeredRef.current = false;
+      isWaitingRerunCompletionRef.current = false;
     }
 
-    prevStatusRef.current = status ?? null;
-  }, [status, showToast]);
+    if (isWaitingRerunCompletionRef.current && status === 'failed') {
+      isWaitingRerunCompletionRef.current = false;
+    }
+  }, [evaluation?.evaluationId, status, showToast]);
 
   const rerunMutation = useMutation({
     mutationFn: rerunModelEvaluation,
@@ -68,11 +84,17 @@ export const useModelEvaluation = () => {
       await queryClient.invalidateQueries({
         queryKey: aiModelQueryKeys.latestModelInfo(),
       });
+
+      await queryClient.refetchQueries({
+        queryKey: aiModelQueryKeys.latestEvaluation(),
+      });
     },
   });
 
   const handleRerun = async () => {
-    if (rerunMutation.isPending || isInProgress) return;
+    if (rerunMutation.isPending || isInProgress) {
+      return;
+    }
 
     const version = latestModelInfo?.modelVersion;
     const datasetVersion = latestModelInfo?.datasetVersion;
@@ -82,8 +104,9 @@ export const useModelEvaluation = () => {
       return;
     }
 
+    rerunBaseEvaluationIdRef.current = evaluation?.evaluationId ?? null;
     rerunMutation.reset();
-    isRerunTriggeredRef.current = true;
+    isWaitingRerunCompletionRef.current = true;
 
     try {
       await rerunMutation.mutateAsync({
@@ -91,13 +114,14 @@ export const useModelEvaluation = () => {
         datasetVersion,
       });
     } catch {
-      isRerunTriggeredRef.current = false;
+      isWaitingRerunCompletionRef.current = false;
     }
   };
 
   return {
     evaluation: isCompleted ? evaluation : null,
     status,
+    progressPercent,
     isInProgress,
     isCompleted,
     isFailed,

--- a/src/features/admin/aiModel/hooks/useModelEvaluation.ts
+++ b/src/features/admin/aiModel/hooks/useModelEvaluation.ts
@@ -9,7 +9,7 @@ import {
 import type { LatestModelEvaluation } from '@/services/admin/aiModelApi';
 import { aiModelQueryKeys } from '@/features/admin/aiModel/constants/aiModelQueryKeys';
 
-const EVALUATION_REFETCH_INTERVAL = 1000;
+const EVALUATION_REFETCH_INTERVAL = 2000;
 
 const isInProgressStatus = (status?: LatestModelEvaluation['status'] | null) => {
   return status === 'queued' || status === 'running';

--- a/src/services/admin/aiModelApi.ts
+++ b/src/services/admin/aiModelApi.ts
@@ -18,6 +18,7 @@ export type LatestModelEvaluation = {
   recall: number;
   f1Score: number;
   status: LatestModelEvaluationStatus;
+  progressPercent: number;
   passed: boolean;
   version: string;
   resultCode: number;


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#33 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- PDF 리포트 현황 섹션에서 차트와 중복되는 교사별 상세 목록을 제거해 정보 구조 단순화
- AI 모델 성능 평가 진행 상태를 진행률 기반으로 확인할 수 있도록 개선

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- PDF 리포트 생성 수 차트와 중복되는 교사별 상세 목록 제거
- SectionCard 공통 border 스타일 추가
- 성능 평가 진행 상태 ProgressBar 구현
- 성능 평가 응답 타입에 progressPercent 필드 반영
- 성능 평가 진행 중 polling 기반 상태 갱신 구현
- 성능 평가 polling 주기를 1초에서 2초로 조정
- 성능 평가 실패 상태 Alert UI 추가
- 짧은 평가 작업에서 진행 UI가 깜빡이지 않도록 지연 표시 처리

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
<img width="1607" height="868" alt="image" src="https://github.com/user-attachments/assets/64086be4-27eb-452e-b475-f28e627df7d6" />

<img width="1607" height="871" alt="image" src="https://github.com/user-attachments/assets/b3764553-620c-412c-af01-da2e86d2ac8c" />
