### PR TITLE
[FIX] 채팅 읽음 표시 및 메시지 전송 오류 수정 #44

### DIFF
--- a/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
@@ -69,13 +69,7 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     }
 
     try {
-      const response = await threadDetailApi.readRoom(chatRoomId);
-
-      if (response.success) {
-        setMessages(prev =>
-          prev.map(message => (message.isMine ? { ...message, unreadCount: 0 } : message))
-        );
-      }
+      await threadDetailApi.readRoom(chatRoomId);
     } catch {
       // 읽음 처리는 부가 동작이므로 실패해도 화면 흐름은 유지합니다.
     }
@@ -274,7 +268,7 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
           sentAt: formatChatMessageDateTime(createdAt),
           content,
           isMine: true,
-          unreadCount: 1,
+          isUnreadByCounterpart: true,
         },
       ]);
 

--- a/src/features/teacher/threadDetail/lib/threadDetailMappers.ts
+++ b/src/features/teacher/threadDetail/lib/threadDetailMappers.ts
@@ -14,7 +14,7 @@ export const toMessageItem = (message: ChatRoomMessageResponse): MessageItem => 
     sentAt: formatChatMessageDateTime(message.createdAt),
     content: message.content || '-',
     isMine: message.isMine,
-    unreadCount: message.unreadCount ?? 0,
+    isUnreadByCounterpart: message.isUnreadByCounterpart,
   };
 };
 

--- a/src/features/teacher/threadDetail/types.ts
+++ b/src/features/teacher/threadDetail/types.ts
@@ -26,7 +26,7 @@ export type ChatRoomMessageResponse = {
   senderRole: string;
   content: string;
   createdAt: string;
-  unreadCount?: number;
+  isUnreadByCounterpart: boolean;
 };
 
 export type ChatRoomMessagesApiResponse = {
@@ -125,5 +125,5 @@ export type MessageItem = {
   sentAt: string;
   content: string;
   isMine: boolean;
-  unreadCount?: number;
+  isUnreadByCounterpart: boolean;
 };

--- a/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
+++ b/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
@@ -3,18 +3,10 @@ import { Alert } from '@/components/common/Alert';
 import { InlineButton } from '@/components/common/InlineButton';
 import { Loader } from '@/components/common/Loader';
 import { Avatar } from '@/components/common/Avatar';
+import type { MessageItem } from '@/features/teacher/threadDetail/types';
 import { IcError, IcRefresh } from '@/icons';
 
 type DetailLoadState = 'loading' | 'error' | 'success';
-
-type MessageItem = {
-  id: number;
-  senderName: string;
-  sentAt: string;
-  content: string;
-  isMine: boolean;
-  unreadCount?: number;
-};
 
 type ChatMessageListProps = {
   loadState: DetailLoadState;
@@ -116,8 +108,8 @@ export const ChatMessageList = ({
 
           <BubbleWrap $isMine={message.isMine}>
             <MessageBubble $isMine={message.isMine}>{message.content}</MessageBubble>
-            {message.isMine && message.unreadCount ? (
-              <UnreadMarker>{message.unreadCount}</UnreadMarker>
+            {message.isMine && message.isUnreadByCounterpart ? (
+              <UnreadMarker>{message.isUnreadByCounterpart}</UnreadMarker>
             ) : null}
           </BubbleWrap>
 


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#44 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 채팅 메시지 목록 응답의 읽음 여부 필드 기준을 실제 API 스펙에 맞게 isUnreadByCounterpart로 수정
- 메시지 타입, 매핑 로직, 렌더링 조건을 isUnreadByCounterpart 기준으로 정리
- 읽음 처리 API 호출 이후 내 메시지의 상대방 안읽음 상태를 프론트에서 임의로 변경하지 않도록 수정
- 상대방 읽음 여부는 메시지 목록 재조회 시 백엔드 응답 기준으로 반영되도록 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- 채팅 메시지 응답 타입을 isUnreadByCounterpart 기준으로 수정
- 메시지 화면 표시 타입에서 unreadCount 기준 제거
- 메시지 매핑 로직에서 isUnreadByCounterpart 값 연결
- 내 메시지의 안읽음 표시 조건을 isUnreadByCounterpart 기준으로 수정
- 메시지 전송 직후 optimistic message에 isUnreadByCounterpart 적용
- readRoom 성공 후 내 메시지의 상대방 안읽음 상태를 임의로 변경하던 로직 제거

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
