### PR TITLE
[FIX] 채팅 안읽음 표시 렌더링 수정 #44

### DIFF
--- a/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
+++ b/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
@@ -107,10 +107,8 @@ export const ChatMessageList = ({
           )}
 
           <BubbleWrap $isMine={message.isMine}>
+            {message.isMine && message.isUnreadByCounterpart && <UnreadMarker>1</UnreadMarker>}
             <MessageBubble $isMine={message.isMine}>{message.content}</MessageBubble>
-            {message.isMine && message.isUnreadByCounterpart ? (
-              <UnreadMarker>{message.isUnreadByCounterpart}</UnreadMarker>
-            ) : null}
           </BubbleWrap>
 
           <MessageTime $isMine={message.isMine}>{message.sentAt}</MessageTime>
@@ -200,9 +198,16 @@ const MessageTime = styled.span<{ $isMine: boolean }>`
 `;
 
 const BubbleWrap = styled.div<{ $isMine: boolean }>`
-  position: relative;
-  max-width: min(62%, 650px);
-  ${({ $isMine }) => ($isMine ? 'margin-right: 0;' : '')}
+  display: flex;
+  align-items: flex-end;
+  justify-content: ${({ $isMine }) => ($isMine ? 'flex-end' : 'flex-start')};
+  max-width: min(72%, 540px);
+  gap: 8px;
+`;
+
+const UnreadMarker = styled.span`
+  ${({ theme }) => theme.fonts.caption};
+  color: ${({ theme }) => theme.colors.brand.primary};
 `;
 
 const MessageBubble = styled.div<{ $isMine: boolean }>`
@@ -213,12 +218,4 @@ const MessageBubble = styled.div<{ $isMine: boolean }>`
   color: ${({ $isMine, theme }) => ($isMine ? theme.colors.text.textW : theme.colors.text.text2)};
   background: ${({ $isMine, theme }) =>
     $isMine ? theme.colors.brand.primary : theme.colors.background.bg1};
-`;
-
-const UnreadMarker = styled.span`
-  ${({ theme }) => theme.fonts.labelXS};
-  position: absolute;
-  left: -14px;
-  bottom: 4px;
-  color: ${({ theme }) => theme.colors.brand.dark};
 `;

--- a/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
+++ b/src/pages/teacher/threadDetail/components/ChatMessageList.tsx
@@ -121,7 +121,6 @@ export const ChatMessageList = ({
 const MessageArea = styled.div`
   flex: 1;
   min-height: 0;
-  background: ${({ theme }) => theme.colors.background.bg4};
   padding: 16px 14px;
   overflow-y: auto;
   overflow-x: hidden;


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 채팅 상세 화면에서 상대방 안읽음 여부가 정상적으로 표시되지 않던 문제 해결
- api의 응답 필드에서 unreadCount를 isUnreadByCounterpart로 수정 후, 렌더링 로직에 반영이 안 되어 boolean 값을 그대로 출력하는 문제
- isUnreadByCounterpart가 true일 때 안읽음 표시로 1이 렌더링되도록 수정
- 채팅방 스타일 조정

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- isUnreadByCounterpart가 true일 때 안읽음 표시 1이 렌더링되도록 수정
- boolean 값을 직접 렌더링하던 기존 안읽음 표시 로직 수정
- 채팅 버블 레이아웃 및 스타일 개선
- ChatMessageList 배경색 제거

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
<img width="1577" height="868" alt="image" src="https://github.com/user-attachments/assets/88b5faa8-cbce-49d7-864f-826606b12f54" />
