### PR TITLE
[FIX] 채팅 메시지 목록 갱신 로직 개선 #48

### DIFF
--- a/src/constants/threadDetailQueryKeys.ts
+++ b/src/constants/threadDetailQueryKeys.ts
@@ -1,0 +1,9 @@
+export const threadDetailQueryKeys = {
+  all: ['teacher', 'threadDetail'] as const,
+
+  detail: (chatRoomId: number) => [...threadDetailQueryKeys.all, chatRoomId, 'detail'] as const,
+
+  messages: (chatRoomId: number) => [...threadDetailQueryKeys.all, chatRoomId, 'messages'] as const,
+
+  threadList: () => ['teacher', 'threadList'] as const,
+};

--- a/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
@@ -9,11 +9,9 @@ import {
 } from '@/constants/inquiryIntent';
 import { INQUIRY_STATUS } from '@/constants/inquiryStatus';
 import { useThreadStatusStore, type ThreadStatus } from '@/stores/threadStatusStore';
-import {
-  getThreadDetailErrorMessage,
-  toAnalysisResult,
-  toMessageItem,
-} from '@/features/teacher/threadDetail/lib';
+import { getThreadDetailErrorMessage, toAnalysisResult } from '@/features/teacher/threadDetail/lib';
+import { useChatMessagesQuery } from '@/features/teacher/threadDetail/queries';
+import { useReadChatRoom, useSendTeacherMessage } from '@/features/teacher/threadDetail/mutations';
 import type {
   AnalysisResult,
   DetailLoadState,
@@ -26,6 +24,8 @@ type UseTeacherThreadDetailParams = {
 };
 
 type ComposerActionMode = 'send' | 'assist';
+
+const FOCUS_REFRESH_THROTTLE_MS = 3000;
 
 export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) => {
   const [status, setStatus] = useState<ThreadStatus>(INQUIRY_STATUS.IN_PROGRESS);
@@ -47,124 +47,129 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
   const [studentName, setStudentName] = useState('');
   const [intentType, setIntentType] = useState<InquiryIntentType>(INQUIRY_INTENT.ETC);
 
-  const [messages, setMessages] = useState<MessageItem[]>([]);
-  const [messagesError, setMessagesError] = useState('');
-  const [messagesPartialError, setMessagesPartialError] = useState('');
-  const [isMessagesLoading, setIsMessagesLoading] = useState(false);
-  const [isMessagesLoadingMore, setIsMessagesLoadingMore] = useState(false);
-  const [messagesNextCursor, setMessagesNextCursor] = useState<number | null>(null);
-  const [messagesHasNext, setMessagesHasNext] = useState(false);
-
   const isAnalyzingRef = useRef(false);
   const isSendingRef = useRef(false);
+  const isMarkingReadRef = useRef(false);
+  const lastFocusedRefreshAtRef = useRef(0);
 
   const setRoomStatus = useThreadStatusStore(state => state.setRoomStatus);
-  const statusByRoomId = useThreadStatusStore(state => state.statusByRoomId);
 
   const isValidChatRoomId = Number.isFinite(chatRoomId) && chatRoomId > 0;
 
+  const {
+    messages,
+    isMessagesLoading,
+    isMessagesLoadingMore,
+    messagesError,
+    messagesPartialError,
+    messagesHasNext,
+    fetchNextMessagesPage,
+    refetchMessages,
+    appendOptimisticMessage,
+  } = useChatMessagesQuery(chatRoomId);
+
+  const sendTeacherMessageMutation = useSendTeacherMessage();
+  const { mutateAsync: readChatRoom } = useReadChatRoom(chatRoomId);
+
   const markMessagesAsRead = useCallback(async () => {
-    if (!isValidChatRoomId) {
+    if (!isValidChatRoomId || isMarkingReadRef.current) {
       return;
     }
 
     try {
-      await threadDetailApi.readRoom(chatRoomId);
+      isMarkingReadRef.current = true;
+      await readChatRoom();
     } catch {
       // 읽음 처리는 부가 동작이므로 실패해도 화면 흐름은 유지합니다.
+    } finally {
+      isMarkingReadRef.current = false;
     }
-  }, [chatRoomId, isValidChatRoomId]);
+  }, [isValidChatRoomId, readChatRoom]);
 
-  const loadChatRoomDetail = useCallback(async () => {
-    if (!isValidChatRoomId) {
-      setLoadState('error');
-      setDetailErrorMessage('대화 정보를 불러올 수 없어요');
-      return;
-    }
-
-    try {
-      setLoadState('loading');
-      setDetailErrorMessage('');
-
-      const response = await threadDetailApi.getChatRoomDetail(chatRoomId);
-      const payload = response.data;
-
-      if (!payload) {
-        throw new Error('채팅방 데이터가 없습니다.');
-      }
-
-      const nextIntentType = getInquiryIntentByType(payload.intentType);
-      const overriddenStatus = statusByRoomId[chatRoomId];
-      const nextStatus = overriddenStatus ?? payload.status;
-
-      setCounterpartName(payload.counterpartName ?? '');
-      setStudentName(payload.studentName ?? '');
-      setIntentType(nextIntentType);
-      setStatus(nextStatus);
-
-      if (!overriddenStatus) {
-        setRoomStatus(chatRoomId, payload.status);
-      }
-
-      setLoadState('success');
-    } catch {
-      setLoadState('error');
-      setDetailErrorMessage('대화 정보를 불러올 수 없어요');
-    }
-  }, [chatRoomId, isValidChatRoomId, setRoomStatus, statusByRoomId]);
-
-  const loadMessages = useCallback(
-    async ({ cursor, append }: { cursor?: number; append?: boolean } = {}) => {
+  const loadChatRoomDetail = useCallback(
+    async ({ shouldShowLoading = true }: { shouldShowLoading?: boolean } = {}) => {
       if (!isValidChatRoomId) {
+        setLoadState('error');
+        setDetailErrorMessage('대화 정보를 불러올 수 없어요');
         return;
       }
 
       try {
-        if (append) {
-          setIsMessagesLoadingMore(true);
-        } else {
-          setIsMessagesLoading(true);
-          setMessagesError('');
+        if (shouldShowLoading) {
+          setLoadState('loading');
         }
 
-        const response = await threadDetailApi.getMessages(chatRoomId, {
-          cursor,
-          size: 20,
-        });
+        setDetailErrorMessage('');
 
+        const response = await threadDetailApi.getChatRoomDetail(chatRoomId);
         const payload = response.data;
 
         if (!payload) {
-          throw new Error('메시지 데이터가 없습니다.');
+          throw new Error('채팅방 데이터가 없습니다.');
         }
 
-        const mappedMessages = payload.messages.map(toMessageItem);
+        const nextIntentType = getInquiryIntentByType(payload.intentType);
+        const overriddenStatus = useThreadStatusStore.getState().statusByRoomId[chatRoomId];
+        const nextStatus = overriddenStatus ?? payload.status;
 
-        setMessages(prev => (append ? [...prev, ...mappedMessages] : mappedMessages));
-        setMessagesNextCursor(payload.nextCursor);
-        setMessagesHasNext(payload.hasNext);
-        setMessagesPartialError('');
+        setCounterpartName(payload.counterpartName ?? '');
+        setStudentName(payload.studentName ?? '');
+        setIntentType(nextIntentType);
+        setStatus(nextStatus);
+
+        if (!overriddenStatus) {
+          setRoomStatus(chatRoomId, payload.status);
+        }
+
+        setLoadState('success');
       } catch {
-        if (append) {
-          setMessagesPartialError('채팅 내역 일부를 불러오지 못했어요.');
-        } else {
-          setMessages([]);
-          setMessagesError('메시지를 불러올 수 없어요.');
-          setMessagesPartialError('');
-        }
-      } finally {
-        setIsMessagesLoading(false);
-        setIsMessagesLoadingMore(false);
+        setLoadState('error');
+        setDetailErrorMessage('대화 정보를 불러올 수 없어요');
       }
     },
-    [chatRoomId, isValidChatRoomId]
+    [chatRoomId, isValidChatRoomId, setRoomStatus]
   );
 
   useEffect(() => {
     void loadChatRoomDetail();
-    void loadMessages();
+  }, [loadChatRoomDetail]);
+
+  useEffect(() => {
+    if (!isValidChatRoomId) {
+      return;
+    }
+
+    const refreshMessagesOnFocus = () => {
+      const now = Date.now();
+
+      if (now - lastFocusedRefreshAtRef.current < FOCUS_REFRESH_THROTTLE_MS) {
+        return;
+      }
+
+      lastFocusedRefreshAtRef.current = now;
+
+      void refetchMessages();
+      void markMessagesAsRead();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshMessagesOnFocus();
+      }
+    };
+
+    window.addEventListener('focus', refreshMessagesOnFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', refreshMessagesOnFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [isValidChatRoomId, markMessagesAsRead, refetchMessages]);
+
+  useEffect(() => {
     void markMessagesAsRead();
-  }, [loadChatRoomDetail, loadMessages, markMessagesAsRead]);
+  }, [chatRoomId, markMessagesAsRead]);
 
   useEffect(() => {
     setAnalysisResult(null);
@@ -182,6 +187,16 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
   const isComposerActionDisabled = !hasMessageInput || isAnalysisRequesting;
   const isUnsafeRisk =
     analysisResult?.riskLevel === 'UNSAFE' || analysisResult?.riskLevel === 'HIGH';
+
+  const resetComposerState = () => {
+    setMessageInput('');
+    setAnalysisResult(null);
+    setLastAnalysisId(null);
+    setAnalysisFeedbackScore(null);
+    setFeedbackSaved(false);
+    setFeedbackErrorMessage('');
+    setSendErrorMessage('');
+  };
 
   const requestMessageAnalysis = useCallback(async () => {
     if (!hasMessageInput || isAnalysisRequesting || isAnalyzingRef.current) {
@@ -251,34 +266,31 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
         content,
       };
 
-      const response = await threadDetailApi.sendMessage(chatRoomId, payload);
+      const response = await sendTeacherMessageMutation.mutateAsync({
+        chatRoomId,
+        payload,
+      });
 
       if (!response.success) {
         throw new Error(response.message || '메시지 전송에 실패했어요');
       }
 
-      const createdAt = new Date().toISOString();
-      const messageId = response.data?.messageId ?? Date.now();
+      const optimisticMessage: MessageItem = {
+        id: response.data?.messageId ?? Date.now(),
+        senderName: '나',
+        sentAt: formatChatMessageDateTime(new Date().toISOString()),
+        content,
+        isMine: true,
+        isUnreadByCounterpart: true,
+      };
 
-      setMessages(prev => [
-        ...prev,
-        {
-          id: messageId,
-          senderName: '나',
-          sentAt: formatChatMessageDateTime(createdAt),
-          content,
-          isMine: true,
-          isUnreadByCounterpart: true,
-        },
-      ]);
+      resetComposerState();
 
-      setMessageInput('');
-      setAnalysisResult(null);
-      setLastAnalysisId(null);
-      setAnalysisFeedbackScore(null);
-      setFeedbackSaved(false);
-      setFeedbackErrorMessage('');
-      setSendErrorMessage('');
+      const refetchResult = await refetchMessages();
+
+      if (!refetchResult.isSuccess) {
+        appendOptimisticMessage(optimisticMessage);
+      }
 
       void markMessagesAsRead();
     } catch (error) {
@@ -290,14 +302,23 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
           const isActuallySent = latestMine?.content?.trim() === content;
 
           if (isActuallySent) {
-            setSendErrorMessage('');
-            setMessageInput('');
-            setAnalysisResult(null);
-            setLastAnalysisId(null);
-            setAnalysisFeedbackScore(null);
-            setFeedbackSaved(false);
-            setFeedbackErrorMessage('');
-            await loadMessages();
+            resetComposerState();
+
+            const refetchResult = await refetchMessages();
+
+            if (!refetchResult.isSuccess) {
+              appendOptimisticMessage({
+                id: latestMine?.messageId ?? Date.now(),
+                senderName: '나',
+                sentAt: formatChatMessageDateTime(
+                  latestMine?.createdAt ?? new Date().toISOString()
+                ),
+                content,
+                isMine: true,
+                isUnreadByCounterpart: latestMine?.isUnreadByCounterpart ?? true,
+              });
+            }
+
             void markMessagesAsRead();
             return;
           }
@@ -313,12 +334,14 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     }
   }, [
     analysisResult?.analysisId,
+    appendOptimisticMessage,
     chatRoomId,
     hasMessageInput,
     isAnalysisRequesting,
-    loadMessages,
     markMessagesAsRead,
     messageInput,
+    refetchMessages,
+    sendTeacherMessageMutation,
   ]);
 
   const handleComposerActionClick = () => {
@@ -408,24 +431,20 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
   };
 
   const handleLoadMoreMessages = () => {
-    if (!messagesHasNext || messagesNextCursor == null || isMessagesLoadingMore) {
+    if (!messagesHasNext || isMessagesLoadingMore) {
       return;
     }
 
-    void loadMessages({ cursor: messagesNextCursor, append: true });
+    void fetchNextMessagesPage();
   };
 
   const handleRetryMissingMessages = () => {
-    if (!messagesHasNext || messagesNextCursor == null || isMessagesLoadingMore) {
-      return;
-    }
-
-    void loadMessages({ cursor: messagesNextCursor, append: true });
+    void refetchMessages();
   };
 
   const handleRetryConversation = async () => {
     await loadChatRoomDetail();
-    await loadMessages();
+    await refetchMessages();
     await markMessagesAsRead();
   };
 

--- a/src/features/teacher/threadDetail/mutations/index.ts
+++ b/src/features/teacher/threadDetail/mutations/index.ts
@@ -1,0 +1,2 @@
+export { useReadChatRoom } from './useReadChatRoom';
+export { useSendTeacherMessage } from './useSendTeacherMessage';

--- a/src/features/teacher/threadDetail/mutations/useReadChatRoom.ts
+++ b/src/features/teacher/threadDetail/mutations/useReadChatRoom.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+
+export const useReadChatRoom = (chatRoomId: number) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => threadDetailApi.readRoom(chatRoomId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: threadDetailQueryKeys.threadList(),
+      });
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/mutations/useSendTeacherMessage.ts
+++ b/src/features/teacher/threadDetail/mutations/useSendTeacherMessage.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+import type { SendTeacherMessageRequest } from '@/features/teacher/threadDetail/types';
+
+type SendTeacherMessageParams = {
+  chatRoomId: number;
+  payload: SendTeacherMessageRequest;
+};
+
+export const useSendTeacherMessage = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ chatRoomId, payload }: SendTeacherMessageParams) => {
+      return threadDetailApi.sendMessage(chatRoomId, payload);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: threadDetailQueryKeys.threadList(),
+      });
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/queries/index.ts
+++ b/src/features/teacher/threadDetail/queries/index.ts
@@ -1,0 +1,1 @@
+export { useChatMessagesQuery } from './useChatMessagesQuery';

--- a/src/features/teacher/threadDetail/queries/useChatMessagesQuery.ts
+++ b/src/features/teacher/threadDetail/queries/useChatMessagesQuery.ts
@@ -1,0 +1,103 @@
+import { useInfiniteQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+import { toMessageItem } from '@/features/teacher/threadDetail/lib';
+import type { MessageItem } from '@/features/teacher/threadDetail/types';
+
+const MESSAGE_PAGE_SIZE = 20;
+const MESSAGE_FOCUS_REFETCH_STALE_TIME = 3000;
+
+type ChatMessagesPage = {
+  messages: MessageItem[];
+  nextCursor: number | null;
+  hasNext: boolean;
+};
+
+export const useChatMessagesQuery = (chatRoomId: number) => {
+  const queryClient = useQueryClient();
+  const isValidChatRoomId = Number.isFinite(chatRoomId) && chatRoomId > 0;
+  const queryKey = threadDetailQueryKeys.messages(chatRoomId);
+
+  const query = useInfiniteQuery({
+    queryKey,
+    enabled: isValidChatRoomId,
+    initialPageParam: undefined as number | undefined,
+    queryFn: async ({ pageParam }) => {
+      const response = await threadDetailApi.getMessages(chatRoomId, {
+        cursor: pageParam,
+        size: MESSAGE_PAGE_SIZE,
+      });
+
+      const payload = response.data;
+
+      if (!payload) {
+        throw new Error('메시지 데이터가 없습니다.');
+      }
+
+      return {
+        messages: payload.messages.map(toMessageItem),
+        nextCursor: payload.nextCursor,
+        hasNext: payload.hasNext,
+      };
+    },
+    getNextPageParam: lastPage => {
+      if (!lastPage.hasNext) {
+        return undefined;
+      }
+
+      return lastPage.nextCursor ?? undefined;
+    },
+    refetchOnWindowFocus: false,
+    staleTime: MESSAGE_FOCUS_REFETCH_STALE_TIME,
+  });
+
+  const hasLoadedMessages = Boolean(query.data);
+  const messages = query.data?.pages.flatMap(page => page.messages) ?? [];
+
+  const appendOptimisticMessage = (message: MessageItem) => {
+    queryClient.setQueryData<InfiniteData<ChatMessagesPage>>(queryKey, previousData => {
+      if (!previousData) {
+        return {
+          pageParams: [undefined],
+          pages: [
+            {
+              messages: [message],
+              nextCursor: null,
+              hasNext: false,
+            },
+          ],
+        };
+      }
+
+      const lastPageIndex = previousData.pages.length - 1;
+
+      return {
+        ...previousData,
+        pages: previousData.pages.map((page, index) => {
+          if (index !== lastPageIndex) {
+            return page;
+          }
+
+          return {
+            ...page,
+            messages: [...page.messages, message],
+          };
+        }),
+      };
+    });
+  };
+
+  return {
+    messages,
+    isMessagesLoading: query.isLoading && !hasLoadedMessages,
+    isMessagesFetching: query.isFetching && hasLoadedMessages,
+    isMessagesLoadingMore: query.isFetchingNextPage,
+    messagesError: query.isError && !hasLoadedMessages ? '메시지를 불러올 수 없어요.' : '',
+    messagesPartialError:
+      query.isError && hasLoadedMessages ? '채팅 내역을 최신 상태로 갱신하지 못했어요.' : '',
+    messagesHasNext: Boolean(query.hasNextPage),
+    fetchNextMessagesPage: query.fetchNextPage,
+    refetchMessages: query.refetch,
+    appendOptimisticMessage,
+  };
+};


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#48 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 채팅방 상세 화면에서 메시지 전송 후 최신 메시지 목록이 정상적으로 반영되지 않던 문제 해결
- 채팅 메시지 목록을 TanStack Query 기반으로 관리하도록 변경
- 메시지 전송 성공 후 서버 메시지 목록을 재조회해 최신 상태가 반영되도록 수정
- 브라우저 포커스 복귀 시 채팅 메시지 목록을 갱신하도록 처리
- 메시지 목록 재조회 실패 시에는 내가 보낸 메시지만 fallback으로 optimistic하게 추가되도록 정리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- 채팅 메시지 목록을 TanStack Query 기반으로 관리하도록 수정
- 커서 기반 메시지 목록 조회를 useInfiniteQuery로 분리
- 메시지 전송 성공 후 서버 메시지 목록을 재조회하도록 수정
- 상대방이 보낸 최신 메시지가 전송 직후 함께 반영되도록 수정
- 브라우저 포커스 복귀 시 채팅 메시지 목록을 갱신하도록 처리
- 메시지 목록 재조회 실패 시 optimistic message fallback 적용
- 메시지 전송 mutation에서 메시지 목록 중복 refetch 제거
- 읽음 처리 mutation과 메시지 목록 갱신 흐름 정리

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
