### PR TITLE
[REFACTOR] 채팅 상세 서버 상태 관리 로직 분리 #50

### DIFF
--- a/src/constants/threadDetailQueryKeys.ts
+++ b/src/constants/threadDetailQueryKeys.ts
@@ -1,9 +1,0 @@
-export const threadDetailQueryKeys = {
-  all: ['teacher', 'threadDetail'] as const,
-
-  detail: (chatRoomId: number) => [...threadDetailQueryKeys.all, chatRoomId, 'detail'] as const,
-
-  messages: (chatRoomId: number) => [...threadDetailQueryKeys.all, chatRoomId, 'messages'] as const,
-
-  threadList: () => ['teacher', 'threadList'] as const,
-};

--- a/src/constants/threadQueryKeys.ts
+++ b/src/constants/threadQueryKeys.ts
@@ -1,0 +1,9 @@
+export const threadQueryKeys = {
+  all: ['teacher', 'threads'] as const,
+
+  threadList: () => [...threadQueryKeys.all, 'list'] as const,
+
+  detail: (chatRoomId: number) => [...threadQueryKeys.all, 'detail', chatRoomId] as const,
+
+  messages: (chatRoomId: number) => [...threadQueryKeys.detail(chatRoomId), 'messages'] as const,
+};

--- a/src/features/teacher/threadDetail/hooks/useRefreshChatMessagesOnFocus.ts
+++ b/src/features/teacher/threadDetail/hooks/useRefreshChatMessagesOnFocus.ts
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+type UseRefreshChatMessagesOnFocusParams = {
+  enabled: boolean;
+  throttleMs: number;
+  onRefresh: () => void;
+};
+
+export const useRefreshChatMessagesOnFocus = ({
+  enabled,
+  throttleMs,
+  onRefresh,
+}: UseRefreshChatMessagesOnFocusParams) => {
+  const lastFocusedRefreshAtRef = useRef(0);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
+    const refreshMessagesOnFocus = () => {
+      const now = Date.now();
+
+      if (now - lastFocusedRefreshAtRef.current < throttleMs) {
+        return;
+      }
+
+      lastFocusedRefreshAtRef.current = now;
+      onRefresh();
+    };
+
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        refreshMessagesOnFocus();
+      }
+    };
+
+    window.addEventListener('focus', refreshMessagesOnFocus);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      window.removeEventListener('focus', refreshMessagesOnFocus);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [enabled, onRefresh, throttleMs]);
+};

--- a/src/features/teacher/threadDetail/hooks/useThreadAnalysisFeedback.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadAnalysisFeedback.ts
@@ -1,0 +1,67 @@
+import { useCallback, useState } from 'react';
+import { useSaveAnalysisFeedback } from '@/features/teacher/threadDetail/mutations';
+import type { AnalysisResult } from '@/features/teacher/threadDetail/types';
+
+type UseThreadAnalysisFeedbackParams = {
+  analysisResult: AnalysisResult | null;
+};
+
+export const useThreadAnalysisFeedback = ({ analysisResult }: UseThreadAnalysisFeedbackParams) => {
+  const [analysisFeedbackScore, setAnalysisFeedbackScore] = useState<number | null>(null);
+  const [feedbackSaved, setFeedbackSaved] = useState(false);
+  const [feedbackErrorMessage, setFeedbackErrorMessage] = useState('');
+
+  const saveAnalysisFeedbackMutation = useSaveAnalysisFeedback();
+
+  const resetFeedbackState = useCallback(() => {
+    setAnalysisFeedbackScore(null);
+    setFeedbackSaved(false);
+    setFeedbackErrorMessage('');
+  }, []);
+
+  const handleAnalysisFeedbackClick = useCallback(
+    async (score: number) => {
+      if (!analysisResult || saveAnalysisFeedbackMutation.isPending) {
+        return;
+      }
+
+      try {
+        setAnalysisFeedbackScore(score);
+        setFeedbackErrorMessage('');
+
+        const response = await saveAnalysisFeedbackMutation.mutateAsync({
+          analysisId: analysisResult.analysisId,
+          score,
+        });
+
+        if (!response.success) {
+          throw new Error(response.message || '피드백 저장에 실패했어요');
+        }
+
+        setFeedbackSaved(true);
+      } catch {
+        setFeedbackSaved(false);
+        setFeedbackErrorMessage('피드백을 저장하지 못했어요');
+      }
+    },
+    [analysisResult, saveAnalysisFeedbackMutation]
+  );
+
+  const handleRetryFeedback = useCallback(() => {
+    if (analysisFeedbackScore == null) {
+      return;
+    }
+
+    void handleAnalysisFeedbackClick(analysisFeedbackScore);
+  }, [analysisFeedbackScore, handleAnalysisFeedbackClick]);
+
+  return {
+    analysisFeedbackScore,
+    isFeedbackSubmitting: saveAnalysisFeedbackMutation.isPending,
+    feedbackSaved,
+    feedbackErrorMessage,
+    resetFeedbackState,
+    handleAnalysisFeedbackClick,
+    handleRetryFeedback,
+  };
+};

--- a/src/features/teacher/threadDetail/hooks/useThreadComposer.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadComposer.ts
@@ -1,0 +1,315 @@
+import { isAxiosError } from 'axios';
+import { useCallback, useState } from 'react';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+import { formatChatMessageDateTime } from '@/utils/formatDateTime';
+import { getThreadDetailErrorMessage, toAnalysisResult } from '@/features/teacher/threadDetail/lib';
+import {
+  useAnalyzeTeacherMessage,
+  useRecheckTeacherMessage,
+  useSaveRecommendationAdoption,
+  useSendTeacherMessage,
+} from '@/features/teacher/threadDetail/mutations';
+import type {
+  AnalysisResult,
+  MessageItem,
+  SendTeacherMessageRequest,
+} from '@/features/teacher/threadDetail/types';
+
+type ComposerActionMode = 'send' | 'assist';
+
+type RefetchMessagesResult = {
+  isSuccess: boolean;
+};
+
+type UseThreadComposerParams = {
+  chatRoomId: number;
+  isValidChatRoomId: boolean;
+  refetchMessages: () => Promise<RefetchMessagesResult>;
+  appendOptimisticMessage: (message: MessageItem) => void;
+  markMessagesAsRead: () => Promise<void>;
+  resetFeedbackState: () => void;
+  onAnalysisResultChange: (analysisResult: AnalysisResult | null) => void;
+};
+
+export const useThreadComposer = ({
+  chatRoomId,
+  isValidChatRoomId,
+  refetchMessages,
+  appendOptimisticMessage,
+  markMessagesAsRead,
+  resetFeedbackState,
+  onAnalysisResultChange,
+}: UseThreadComposerParams) => {
+  const [messageInput, setMessageInput] = useState('');
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
+  const [analysisErrorMessage, setAnalysisErrorMessage] = useState('');
+  const [sendErrorMessage, setSendErrorMessage] = useState('');
+  const [lastAnalysisId, setLastAnalysisId] = useState<number | null>(null);
+
+  const analyzeTeacherMessageMutation = useAnalyzeTeacherMessage();
+  const recheckTeacherMessageMutation = useRecheckTeacherMessage();
+  const sendTeacherMessageMutation = useSendTeacherMessage();
+  const saveRecommendationAdoptionMutation = useSaveRecommendationAdoption();
+
+  const isAnalysisRequesting =
+    analyzeTeacherMessageMutation.isPending || recheckTeacherMessageMutation.isPending;
+
+  const isSendingMessage = sendTeacherMessageMutation.isPending;
+
+  const hasMessageInput = messageInput.trim().length > 0;
+  const composerActionMode: ComposerActionMode = analysisResult ? 'send' : 'assist';
+  const isComposerActionDisabled = !hasMessageInput || isAnalysisRequesting || isSendingMessage;
+  const isUnsafeRisk = analysisResult?.riskLevel === 'UNSAFE';
+
+  const resetComposerState = useCallback(() => {
+    setMessageInput('');
+    setAnalysisResult(null);
+    setLastAnalysisId(null);
+    setAnalysisErrorMessage('');
+    setSendErrorMessage('');
+
+    onAnalysisResultChange(null);
+    resetFeedbackState();
+  }, [onAnalysisResultChange, resetFeedbackState]);
+
+  const resetComposerForRoom = useCallback(() => {
+    resetComposerState();
+  }, [resetComposerState]);
+
+  const requestMessageAnalysis = useCallback(async () => {
+    if (!hasMessageInput || isAnalysisRequesting || isSendingMessage) {
+      return null;
+    }
+
+    try {
+      setAnalysisErrorMessage('');
+      setSendErrorMessage('');
+      setAnalysisResult(null);
+      onAnalysisResultChange(null);
+
+      if (!isValidChatRoomId) {
+        throw new Error('유효하지 않은 채팅방입니다.');
+      }
+
+      const content = messageInput.trim();
+
+      const response = lastAnalysisId
+        ? await recheckTeacherMessageMutation.mutateAsync({
+            analysisId: lastAnalysisId,
+            content,
+          })
+        : await analyzeTeacherMessageMutation.mutateAsync({
+            chatRoomId,
+            content,
+          });
+
+      const nextAnalysisResult = toAnalysisResult(response);
+
+      setAnalysisResult(nextAnalysisResult);
+      setLastAnalysisId(nextAnalysisResult.analysisId);
+      onAnalysisResultChange(nextAnalysisResult);
+      resetFeedbackState();
+
+      return nextAnalysisResult;
+    } catch (error) {
+      setAnalysisErrorMessage(getThreadDetailErrorMessage(error, '메시지 분석에 실패했어요'));
+      return null;
+    }
+  }, [
+    analyzeTeacherMessageMutation,
+    chatRoomId,
+    hasMessageInput,
+    isAnalysisRequesting,
+    isSendingMessage,
+    isValidChatRoomId,
+    lastAnalysisId,
+    messageInput,
+    onAnalysisResultChange,
+    recheckTeacherMessageMutation,
+    resetFeedbackState,
+  ]);
+
+  const sendTeacherMessage = useCallback(async () => {
+    if (!hasMessageInput || isAnalysisRequesting || isSendingMessage) {
+      return;
+    }
+
+    try {
+      setAnalysisErrorMessage('');
+
+      const content = messageInput.trim();
+
+      if (!analysisResult?.analysisId) {
+        throw new Error('분석 결과가 없어 메시지를 전송할 수 없어요');
+      }
+
+      const payload: SendTeacherMessageRequest = {
+        analysisId: analysisResult.analysisId,
+        content,
+      };
+
+      const response = await sendTeacherMessageMutation.mutateAsync({
+        chatRoomId,
+        payload,
+      });
+
+      if (!response.success) {
+        throw new Error(response.message || '메시지 전송에 실패했어요');
+      }
+
+      const optimisticMessage: MessageItem = {
+        id: response.data?.messageId ?? Date.now(),
+        senderName: '나',
+        sentAt: formatChatMessageDateTime(new Date().toISOString()),
+        content,
+        isMine: true,
+        isUnreadByCounterpart: true,
+      };
+
+      resetComposerState();
+
+      const refetchResult = await refetchMessages();
+
+      if (!refetchResult.isSuccess) {
+        appendOptimisticMessage(optimisticMessage);
+      }
+
+      void markMessagesAsRead();
+    } catch (error) {
+      if (isAxiosError(error) && error.response?.status === 400) {
+        try {
+          const content = messageInput.trim();
+          const response = await threadDetailApi.getMessages(chatRoomId, { size: 5 });
+          const latestMine = response.data?.messages?.find(message => message.isMine);
+          const isActuallySent = latestMine?.content?.trim() === content;
+
+          if (isActuallySent) {
+            resetComposerState();
+
+            const refetchResult = await refetchMessages();
+
+            if (!refetchResult.isSuccess) {
+              appendOptimisticMessage({
+                id: latestMine?.messageId ?? Date.now(),
+                senderName: '나',
+                sentAt: formatChatMessageDateTime(
+                  latestMine?.createdAt ?? new Date().toISOString()
+                ),
+                content,
+                isMine: true,
+                isUnreadByCounterpart: latestMine?.isUnreadByCounterpart ?? true,
+              });
+            }
+
+            void markMessagesAsRead();
+            return;
+          }
+        } catch {
+          // 재확인 실패 시 일반 오류 처리로 진행합니다.
+        }
+      }
+
+      setSendErrorMessage(getThreadDetailErrorMessage(error, '메시지를 전송하지 못했어요'));
+    }
+  }, [
+    analysisResult?.analysisId,
+    appendOptimisticMessage,
+    chatRoomId,
+    hasMessageInput,
+    isAnalysisRequesting,
+    isSendingMessage,
+    markMessagesAsRead,
+    messageInput,
+    refetchMessages,
+    resetComposerState,
+    sendTeacherMessageMutation,
+  ]);
+
+  const handleComposerActionClick = useCallback(() => {
+    if (composerActionMode === 'assist') {
+      void requestMessageAnalysis();
+      return;
+    }
+
+    void sendTeacherMessage();
+  }, [composerActionMode, requestMessageAnalysis, sendTeacherMessage]);
+
+  const handleMessageInputChange = useCallback(
+    (nextValue: string) => {
+      setMessageInput(nextValue);
+
+      if (analysisResult) {
+        setAnalysisResult(null);
+        onAnalysisResultChange(null);
+        resetFeedbackState();
+      }
+
+      if (sendErrorMessage) {
+        setSendErrorMessage('');
+      }
+
+      if (analysisErrorMessage) {
+        setAnalysisErrorMessage('');
+      }
+    },
+    [
+      analysisErrorMessage,
+      analysisResult,
+      onAnalysisResultChange,
+      resetFeedbackState,
+      sendErrorMessage,
+    ]
+  );
+
+  const handleRetryAnalysis = useCallback(() => {
+    void requestMessageAnalysis();
+  }, [requestMessageAnalysis]);
+
+  const handleApplyRecommendedReply = useCallback(async () => {
+    if (!analysisResult?.recommendedMessage) {
+      return;
+    }
+
+    try {
+      const response = await saveRecommendationAdoptionMutation.mutateAsync(
+        analysisResult.analysisId
+      );
+
+      if (!response.success) {
+        throw new Error(response.message || '추천문장 채택 저장에 실패했어요');
+      }
+    } catch {
+      // 채택 저장 실패하더라도 추천문장 적용 UX는 유지합니다.
+    }
+
+    setMessageInput(analysisResult.recommendedMessage);
+    setAnalysisResult(null);
+    setAnalysisErrorMessage('');
+    setSendErrorMessage('');
+
+    onAnalysisResultChange(null);
+    resetFeedbackState();
+  }, [
+    analysisResult,
+    onAnalysisResultChange,
+    resetFeedbackState,
+    saveRecommendationAdoptionMutation,
+  ]);
+
+  return {
+    messageInput,
+    analysisResult,
+    analysisErrorMessage,
+    sendErrorMessage,
+    isAnalysisRequesting,
+    isSendingMessage,
+    composerActionMode,
+    isComposerActionDisabled,
+    isUnsafeRisk,
+    resetComposerForRoom,
+    handleMessageInputChange,
+    handleComposerActionClick,
+    handleRetryAnalysis,
+    handleApplyRecommendedReply,
+  };
+};

--- a/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
@@ -1,60 +1,30 @@
-import { isAxiosError } from 'axios';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { threadDetailApi } from '@/services/teacher/threadDetailApi';
-import { formatChatMessageDateTime } from '@/utils/formatDateTime';
+import { getInquiryIntentByType, type InquiryIntentType } from '@/constants/inquiryIntent';
+import type { AnalysisResult, DetailLoadState } from '@/features/teacher/threadDetail/types';
 import {
-  getInquiryIntentByType,
-  INQUIRY_INTENT,
-  type InquiryIntentType,
-} from '@/constants/inquiryIntent';
-import { INQUIRY_STATUS } from '@/constants/inquiryStatus';
-import { useThreadStatusStore, type ThreadStatus } from '@/stores/threadStatusStore';
-import { getThreadDetailErrorMessage, toAnalysisResult } from '@/features/teacher/threadDetail/lib';
-import { useChatMessagesQuery } from '@/features/teacher/threadDetail/queries';
-import { useReadChatRoom, useSendTeacherMessage } from '@/features/teacher/threadDetail/mutations';
-import type {
-  AnalysisResult,
-  DetailLoadState,
-  MessageItem,
-  SendTeacherMessageRequest,
-} from '@/features/teacher/threadDetail/types';
+  useChatMessagesQuery,
+  useChatRoomDetailQuery,
+} from '@/features/teacher/threadDetail/queries';
+import { useReadChatRoom } from '@/features/teacher/threadDetail/mutations';
+import { useRefreshChatMessagesOnFocus } from '@/features/teacher/threadDetail/hooks/useRefreshChatMessagesOnFocus';
+import { useThreadAnalysisFeedback } from '@/features/teacher/threadDetail/hooks/useThreadAnalysisFeedback';
+import { useThreadComposer } from '@/features/teacher/threadDetail/hooks/useThreadComposer';
+import { useThreadStatusControl } from '@/features/teacher/threadDetail/hooks/useThreadStatusControl';
 
 type UseTeacherThreadDetailParams = {
   chatRoomId: number;
 };
 
-type ComposerActionMode = 'send' | 'assist';
-
 const FOCUS_REFRESH_THROTTLE_MS = 3000;
 
 export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) => {
-  const [status, setStatus] = useState<ThreadStatus>(INQUIRY_STATUS.IN_PROGRESS);
-  const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
-  const [messageInput, setMessageInput] = useState('');
-  const [analysisResult, setAnalysisResult] = useState<AnalysisResult | null>(null);
-  const [analysisFeedbackScore, setAnalysisFeedbackScore] = useState<number | null>(null);
-  const [isFeedbackSubmitting, setIsFeedbackSubmitting] = useState(false);
-  const [feedbackSaved, setFeedbackSaved] = useState(false);
-  const [feedbackErrorMessage, setFeedbackErrorMessage] = useState('');
-  const [analysisErrorMessage, setAnalysisErrorMessage] = useState('');
-  const [sendErrorMessage, setSendErrorMessage] = useState('');
-  const [lastAnalysisId, setLastAnalysisId] = useState<number | null>(null);
-  const [isStatusUpdating, setIsStatusUpdating] = useState(false);
-  const [isAnalysisRequesting, setIsAnalysisRequesting] = useState(false);
-  const [loadState, setLoadState] = useState<DetailLoadState>('loading');
-  const [detailErrorMessage, setDetailErrorMessage] = useState('');
-  const [counterpartName, setCounterpartName] = useState('');
-  const [studentName, setStudentName] = useState('');
-  const [intentType, setIntentType] = useState<InquiryIntentType>(INQUIRY_INTENT.ETC);
-
-  const isAnalyzingRef = useRef(false);
-  const isSendingRef = useRef(false);
+  const [currentAnalysisResult, setCurrentAnalysisResult] = useState<AnalysisResult | null>(null);
   const isMarkingReadRef = useRef(false);
-  const lastFocusedRefreshAtRef = useRef(0);
-
-  const setRoomStatus = useThreadStatusStore(state => state.setRoomStatus);
 
   const isValidChatRoomId = Number.isFinite(chatRoomId) && chatRoomId > 0;
+
+  const chatRoomDetailQuery = useChatRoomDetailQuery(chatRoomId);
+  const chatRoomDetail = chatRoomDetailQuery.data;
 
   const {
     messages,
@@ -68,7 +38,6 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     appendOptimisticMessage,
   } = useChatMessagesQuery(chatRoomId);
 
-  const sendTeacherMessageMutation = useSendTeacherMessage();
   const { mutateAsync: readChatRoom } = useReadChatRoom(chatRoomId);
 
   const markMessagesAsRead = useCallback(async () => {
@@ -86,349 +55,85 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     }
   }, [isValidChatRoomId, readChatRoom]);
 
-  const loadChatRoomDetail = useCallback(
-    async ({ shouldShowLoading = true }: { shouldShowLoading?: boolean } = {}) => {
-      if (!isValidChatRoomId) {
-        setLoadState('error');
-        setDetailErrorMessage('대화 정보를 불러올 수 없어요');
-        return;
-      }
+  const refreshMessages = useCallback(() => {
+    void refetchMessages();
+    void markMessagesAsRead();
+  }, [markMessagesAsRead, refetchMessages]);
 
-      try {
-        if (shouldShowLoading) {
-          setLoadState('loading');
-        }
-
-        setDetailErrorMessage('');
-
-        const response = await threadDetailApi.getChatRoomDetail(chatRoomId);
-        const payload = response.data;
-
-        if (!payload) {
-          throw new Error('채팅방 데이터가 없습니다.');
-        }
-
-        const nextIntentType = getInquiryIntentByType(payload.intentType);
-        const overriddenStatus = useThreadStatusStore.getState().statusByRoomId[chatRoomId];
-        const nextStatus = overriddenStatus ?? payload.status;
-
-        setCounterpartName(payload.counterpartName ?? '');
-        setStudentName(payload.studentName ?? '');
-        setIntentType(nextIntentType);
-        setStatus(nextStatus);
-
-        if (!overriddenStatus) {
-          setRoomStatus(chatRoomId, payload.status);
-        }
-
-        setLoadState('success');
-      } catch {
-        setLoadState('error');
-        setDetailErrorMessage('대화 정보를 불러올 수 없어요');
-      }
-    },
-    [chatRoomId, isValidChatRoomId, setRoomStatus]
-  );
-
-  useEffect(() => {
-    void loadChatRoomDetail();
-  }, [loadChatRoomDetail]);
-
-  useEffect(() => {
-    if (!isValidChatRoomId) {
-      return;
-    }
-
-    const refreshMessagesOnFocus = () => {
-      const now = Date.now();
-
-      if (now - lastFocusedRefreshAtRef.current < FOCUS_REFRESH_THROTTLE_MS) {
-        return;
-      }
-
-      lastFocusedRefreshAtRef.current = now;
-
-      void refetchMessages();
-      void markMessagesAsRead();
-    };
-
-    const handleVisibilityChange = () => {
-      if (document.visibilityState === 'visible') {
-        refreshMessagesOnFocus();
-      }
-    };
-
-    window.addEventListener('focus', refreshMessagesOnFocus);
-    document.addEventListener('visibilitychange', handleVisibilityChange);
-
-    return () => {
-      window.removeEventListener('focus', refreshMessagesOnFocus);
-      document.removeEventListener('visibilitychange', handleVisibilityChange);
-    };
-  }, [isValidChatRoomId, markMessagesAsRead, refetchMessages]);
+  useRefreshChatMessagesOnFocus({
+    enabled: isValidChatRoomId,
+    throttleMs: FOCUS_REFRESH_THROTTLE_MS,
+    onRefresh: refreshMessages,
+  });
 
   useEffect(() => {
     void markMessagesAsRead();
   }, [chatRoomId, markMessagesAsRead]);
 
-  useEffect(() => {
-    setAnalysisResult(null);
-    setLastAnalysisId(null);
-    setAnalysisFeedbackScore(null);
-    setFeedbackSaved(false);
-    setFeedbackErrorMessage('');
-    setAnalysisErrorMessage('');
-    setSendErrorMessage('');
-    setMessageInput('');
-  }, [chatRoomId]);
+  const { status, isStatusMenuOpen, isStatusUpdating, setIsStatusMenuOpen, handleSelectStatus } =
+    useThreadStatusControl({
+      chatRoomId,
+      isValidChatRoomId,
+      serverStatus: chatRoomDetail?.status,
+    });
 
-  const hasMessageInput = messageInput.trim().length > 0;
-  const composerActionMode: ComposerActionMode = analysisResult ? 'send' : 'assist';
-  const isComposerActionDisabled = !hasMessageInput || isAnalysisRequesting;
-  const isUnsafeRisk =
-    analysisResult?.riskLevel === 'UNSAFE' || analysisResult?.riskLevel === 'HIGH';
+  const {
+    analysisFeedbackScore,
+    isFeedbackSubmitting,
+    feedbackSaved,
+    feedbackErrorMessage,
+    resetFeedbackState,
+    handleAnalysisFeedbackClick,
+    handleRetryFeedback,
+  } = useThreadAnalysisFeedback({
+    analysisResult: currentAnalysisResult,
+  });
 
-  const resetComposerState = () => {
-    setMessageInput('');
-    setAnalysisResult(null);
-    setLastAnalysisId(null);
-    setAnalysisFeedbackScore(null);
-    setFeedbackSaved(false);
-    setFeedbackErrorMessage('');
-    setSendErrorMessage('');
-  };
-
-  const requestMessageAnalysis = useCallback(async () => {
-    if (!hasMessageInput || isAnalysisRequesting || isAnalyzingRef.current) {
-      return null;
-    }
-
-    try {
-      isAnalyzingRef.current = true;
-      setIsAnalysisRequesting(true);
-      setAnalysisErrorMessage('');
-      setSendErrorMessage('');
-      setAnalysisResult(null);
-
-      if (!isValidChatRoomId) {
-        throw new Error('유효하지 않은 채팅방입니다.');
-      }
-
-      const content = messageInput.trim();
-
-      const response = lastAnalysisId
-        ? await threadDetailApi.recheckMessage(lastAnalysisId, content)
-        : await threadDetailApi.analyzeMessage(chatRoomId, content);
-
-      const nextAnalysisResult = toAnalysisResult(response);
-
-      setAnalysisResult(nextAnalysisResult);
-      setLastAnalysisId(nextAnalysisResult.analysisId);
-      setAnalysisFeedbackScore(null);
-      setFeedbackSaved(false);
-      setFeedbackErrorMessage('');
-
-      return nextAnalysisResult;
-    } catch (error) {
-      setAnalysisErrorMessage(getThreadDetailErrorMessage(error, '메시지 분석에 실패했어요'));
-      return null;
-    } finally {
-      isAnalyzingRef.current = false;
-      setIsAnalysisRequesting(false);
-    }
-  }, [
-    chatRoomId,
-    hasMessageInput,
+  const {
+    messageInput,
+    analysisResult,
+    analysisErrorMessage,
+    sendErrorMessage,
     isAnalysisRequesting,
+    isSendingMessage,
+    composerActionMode,
+    isComposerActionDisabled,
+    isUnsafeRisk,
+    resetComposerForRoom,
+    handleMessageInputChange,
+    handleComposerActionClick,
+    handleRetryAnalysis,
+    handleApplyRecommendedReply,
+  } = useThreadComposer({
+    chatRoomId,
     isValidChatRoomId,
-    lastAnalysisId,
-    messageInput,
-  ]);
-
-  const sendTeacherMessage = useCallback(async () => {
-    if (!hasMessageInput || isAnalysisRequesting || isSendingRef.current) {
-      return;
-    }
-
-    try {
-      isSendingRef.current = true;
-      setIsAnalysisRequesting(true);
-      setAnalysisErrorMessage('');
-
-      const content = messageInput.trim();
-
-      if (!analysisResult?.analysisId) {
-        throw new Error('분석 결과가 없어 메시지를 전송할 수 없어요');
-      }
-
-      const payload: SendTeacherMessageRequest = {
-        analysisId: analysisResult.analysisId,
-        content,
-      };
-
-      const response = await sendTeacherMessageMutation.mutateAsync({
-        chatRoomId,
-        payload,
-      });
-
-      if (!response.success) {
-        throw new Error(response.message || '메시지 전송에 실패했어요');
-      }
-
-      const optimisticMessage: MessageItem = {
-        id: response.data?.messageId ?? Date.now(),
-        senderName: '나',
-        sentAt: formatChatMessageDateTime(new Date().toISOString()),
-        content,
-        isMine: true,
-        isUnreadByCounterpart: true,
-      };
-
-      resetComposerState();
-
-      const refetchResult = await refetchMessages();
-
-      if (!refetchResult.isSuccess) {
-        appendOptimisticMessage(optimisticMessage);
-      }
-
-      void markMessagesAsRead();
-    } catch (error) {
-      if (isAxiosError(error) && error.response?.status === 400) {
-        try {
-          const content = messageInput.trim();
-          const response = await threadDetailApi.getMessages(chatRoomId, { size: 5 });
-          const latestMine = response.data?.messages?.find(message => message.isMine);
-          const isActuallySent = latestMine?.content?.trim() === content;
-
-          if (isActuallySent) {
-            resetComposerState();
-
-            const refetchResult = await refetchMessages();
-
-            if (!refetchResult.isSuccess) {
-              appendOptimisticMessage({
-                id: latestMine?.messageId ?? Date.now(),
-                senderName: '나',
-                sentAt: formatChatMessageDateTime(
-                  latestMine?.createdAt ?? new Date().toISOString()
-                ),
-                content,
-                isMine: true,
-                isUnreadByCounterpart: latestMine?.isUnreadByCounterpart ?? true,
-              });
-            }
-
-            void markMessagesAsRead();
-            return;
-          }
-        } catch {
-          // 재확인 실패 시 일반 오류 처리로 진행합니다.
-        }
-      }
-
-      setSendErrorMessage(getThreadDetailErrorMessage(error, '메시지를 전송하지 못했어요'));
-    } finally {
-      isSendingRef.current = false;
-      setIsAnalysisRequesting(false);
-    }
-  }, [
-    analysisResult?.analysisId,
-    appendOptimisticMessage,
-    chatRoomId,
-    hasMessageInput,
-    isAnalysisRequesting,
-    markMessagesAsRead,
-    messageInput,
     refetchMessages,
-    sendTeacherMessageMutation,
-  ]);
+    appendOptimisticMessage,
+    markMessagesAsRead,
+    resetFeedbackState,
+    onAnalysisResultChange: setCurrentAnalysisResult,
+  });
 
-  const handleComposerActionClick = () => {
-    if (composerActionMode === 'assist') {
-      void requestMessageAnalysis();
-      return;
-    }
+  useEffect(() => {
+    resetComposerForRoom();
+    resetFeedbackState();
+    setCurrentAnalysisResult(null);
+  }, [chatRoomId, resetComposerForRoom, resetFeedbackState]);
 
-    void sendTeacherMessage();
-  };
+  const counterpartName = chatRoomDetail?.counterpartName ?? '';
+  const studentName = chatRoomDetail?.studentName ?? '';
+  const intentType: InquiryIntentType = getInquiryIntentByType(chatRoomDetail?.intentType);
 
-  const handleMessageInputChange = (nextValue: string) => {
-    setMessageInput(nextValue);
+  const loadState: DetailLoadState = !isValidChatRoomId
+    ? 'error'
+    : chatRoomDetailQuery.isLoading
+      ? 'loading'
+      : chatRoomDetailQuery.isError
+        ? 'error'
+        : 'success';
 
-    if (analysisResult) {
-      setAnalysisResult(null);
-    }
-
-    if (sendErrorMessage) {
-      setSendErrorMessage('');
-    }
-
-    if (analysisErrorMessage) {
-      setAnalysisErrorMessage('');
-    }
-  };
-
-  const handleRetryAnalysis = () => {
-    void requestMessageAnalysis();
-  };
-
-  const handleApplyRecommendedReply = async () => {
-    if (!analysisResult?.recommendedReply) {
-      return;
-    }
-
-    try {
-      const response = await threadDetailApi.saveRecommendationAdoption(analysisResult.analysisId);
-
-      if (!response.success) {
-        throw new Error(response.message || '추천문장 채택 저장에 실패했어요');
-      }
-    } catch {
-      // 채택 저장 실패하더라도 추천문장 적용 UX는 유지합니다.
-    }
-
-    setMessageInput(analysisResult.recommendedReply);
-    setAnalysisResult(null);
-    setAnalysisFeedbackScore(null);
-    setFeedbackSaved(false);
-    setFeedbackErrorMessage('');
-    setAnalysisErrorMessage('');
-    setSendErrorMessage('');
-  };
-
-  const handleAnalysisFeedbackClick = async (score: number) => {
-    if (!analysisResult || isFeedbackSubmitting) {
-      return;
-    }
-
-    try {
-      setIsFeedbackSubmitting(true);
-      setAnalysisFeedbackScore(score);
-      setFeedbackErrorMessage('');
-
-      const response = await threadDetailApi.saveAnalysisFeedback(analysisResult.analysisId, score);
-
-      if (!response.success) {
-        throw new Error(response.message || '피드백 저장에 실패했어요');
-      }
-
-      setFeedbackSaved(true);
-    } catch {
-      setFeedbackSaved(false);
-      setFeedbackErrorMessage('피드백을 저장하지 못했어요');
-    } finally {
-      setIsFeedbackSubmitting(false);
-    }
-  };
-
-  const handleRetryFeedback = () => {
-    if (analysisFeedbackScore == null) {
-      return;
-    }
-
-    void handleAnalysisFeedbackClick(analysisFeedbackScore);
-  };
+  const detailErrorMessage =
+    !isValidChatRoomId || chatRoomDetailQuery.isError ? '대화 정보를 불러올 수 없어요' : '';
 
   const handleLoadMoreMessages = () => {
     if (!messagesHasNext || isMessagesLoadingMore) {
@@ -443,40 +148,9 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
   };
 
   const handleRetryConversation = async () => {
-    await loadChatRoomDetail();
+    await chatRoomDetailQuery.refetch();
     await refetchMessages();
     await markMessagesAsRead();
-  };
-
-  const handleSelectStatus = async (nextStatus: ThreadStatus) => {
-    if (isStatusUpdating) {
-      return;
-    }
-
-    const previousStatus = status;
-
-    setStatus(nextStatus);
-    setRoomStatus(chatRoomId, nextStatus);
-    setIsStatusMenuOpen(false);
-
-    if (!isValidChatRoomId) {
-      return;
-    }
-
-    try {
-      setIsStatusUpdating(true);
-
-      const response = await threadDetailApi.updateStatus(chatRoomId, nextStatus);
-
-      if (!response.success) {
-        throw new Error(response.message || '처리 상태 변경에 실패했어요');
-      }
-    } catch {
-      setStatus(previousStatus);
-      setRoomStatus(chatRoomId, previousStatus);
-    } finally {
-      setIsStatusUpdating(false);
-    }
   };
 
   return {
@@ -492,6 +166,7 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     sendErrorMessage,
     isStatusUpdating,
     isAnalysisRequesting,
+    isSendingMessage,
     loadState,
     detailErrorMessage,
     counterpartName,

--- a/src/features/teacher/threadDetail/hooks/useThreadStatusControl.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadStatusControl.ts
@@ -1,0 +1,78 @@
+import { useCallback, useEffect, useState } from 'react';
+import { INQUIRY_STATUS } from '@/constants/inquiryStatus';
+import { useUpdateChatRoomStatus } from '@/features/teacher/threadDetail/mutations';
+import { useThreadStatusStore, type ThreadStatus } from '@/stores/threadStatusStore';
+
+type UseThreadStatusControlParams = {
+  chatRoomId: number;
+  isValidChatRoomId: boolean;
+  serverStatus?: ThreadStatus;
+};
+
+export const useThreadStatusControl = ({
+  chatRoomId,
+  isValidChatRoomId,
+  serverStatus,
+}: UseThreadStatusControlParams) => {
+  const [status, setStatus] = useState<ThreadStatus>(INQUIRY_STATUS.IN_PROGRESS);
+  const [isStatusMenuOpen, setIsStatusMenuOpen] = useState(false);
+
+  const setRoomStatus = useThreadStatusStore(state => state.setRoomStatus);
+  const updateChatRoomStatusMutation = useUpdateChatRoomStatus();
+
+  useEffect(() => {
+    if (!serverStatus) {
+      return;
+    }
+
+    const overriddenStatus = useThreadStatusStore.getState().statusByRoomId[chatRoomId];
+    const nextStatus = overriddenStatus ?? serverStatus;
+
+    setStatus(nextStatus);
+
+    if (!overriddenStatus) {
+      setRoomStatus(chatRoomId, serverStatus);
+    }
+  }, [chatRoomId, serverStatus, setRoomStatus]);
+
+  const handleSelectStatus = useCallback(
+    async (nextStatus: ThreadStatus) => {
+      if (updateChatRoomStatusMutation.isPending) {
+        return;
+      }
+
+      const previousStatus = status;
+
+      setStatus(nextStatus);
+      setRoomStatus(chatRoomId, nextStatus);
+      setIsStatusMenuOpen(false);
+
+      if (!isValidChatRoomId) {
+        return;
+      }
+
+      try {
+        const response = await updateChatRoomStatusMutation.mutateAsync({
+          chatRoomId,
+          status: nextStatus,
+        });
+
+        if (!response.success) {
+          throw new Error(response.message || '처리 상태 변경에 실패했어요');
+        }
+      } catch {
+        setStatus(previousStatus);
+        setRoomStatus(chatRoomId, previousStatus);
+      }
+    },
+    [chatRoomId, isValidChatRoomId, setRoomStatus, status, updateChatRoomStatusMutation]
+  );
+
+  return {
+    status,
+    isStatusMenuOpen,
+    isStatusUpdating: updateChatRoomStatusMutation.isPending,
+    setIsStatusMenuOpen,
+    handleSelectStatus,
+  };
+};

--- a/src/features/teacher/threadDetail/lib/threadDetailMappers.ts
+++ b/src/features/teacher/threadDetail/lib/threadDetailMappers.ts
@@ -18,17 +18,40 @@ export const toMessageItem = (message: ChatRoomMessageResponse): MessageItem => 
   };
 };
 
-export const toAnalysisResult = (
-  response: AnalyzeTeacherMessageResponse | RecheckTeacherMessageResponse
-): AnalysisResult => {
-  if (!response.success || !response.data) {
-    throw new Error(response.message || '메시지 분석에 실패했어요');
+type AnalysisResponse = AnalyzeTeacherMessageResponse | RecheckTeacherMessageResponse;
+
+const ANALYSIS_RESULT_TEXT: Record<
+  AnalysisResult['riskLevel'],
+  {
+    title: string;
+    description: string;
+  }
+> = {
+  SAFE: {
+    title: '문제 없는 메시지예요',
+    description: '현재 메시지는 차분하고 명확해요. 그대로 보내셔도 괜찮아요.',
+  },
+  UNSAFE: {
+    title: '오해가 발생할 수 있는 메시지예요',
+    description:
+      '메시지의 의도와 다르게 받아들여질 가능성이 있어요. 더 부드럽고 명확한 문장으로 바꿔보는 것을 추천드려요.',
+  },
+};
+
+export const toAnalysisResult = (response: AnalysisResponse): AnalysisResult => {
+  const payload = response.data;
+
+  if (!response.success || !payload) {
+    throw new Error(response.message || '메시지 분석 결과를 불러올 수 없어요');
   }
 
+  const resultText = ANALYSIS_RESULT_TEXT[payload.riskLevel];
+
   return {
-    analysisId: response.data.analysisId,
-    riskLevel: response.data.riskLevel,
-    summary: response.message || '메시지 분석이 완료되었습니다.',
-    recommendedReply: response.data.recommendedMessage?.trim() || null,
+    analysisId: payload.analysisId,
+    riskLevel: payload.riskLevel,
+    title: resultText.title,
+    description: resultText.description,
+    recommendedMessage: payload.recommendedMessage,
   };
 };

--- a/src/features/teacher/threadDetail/mutations/index.ts
+++ b/src/features/teacher/threadDetail/mutations/index.ts
@@ -1,2 +1,7 @@
-export { useReadChatRoom } from './useReadChatRoom';
-export { useSendTeacherMessage } from './useSendTeacherMessage';
+export { useAnalyzeTeacherMessage } from '@/features/teacher/threadDetail/mutations/useAnalyzeTeacherMessage';
+export { useReadChatRoom } from '@/features/teacher/threadDetail/mutations/useReadChatRoom';
+export { useRecheckTeacherMessage } from '@/features/teacher/threadDetail/mutations/useRecheckTeacherMessage';
+export { useSaveAnalysisFeedback } from '@/features/teacher/threadDetail/mutations/useSaveAnalysisFeedback';
+export { useSaveRecommendationAdoption } from '@/features/teacher/threadDetail/mutations/useSaveRecommendationAdoption';
+export { useSendTeacherMessage } from '@/features/teacher/threadDetail/mutations/useSendTeacherMessage';
+export { useUpdateChatRoomStatus } from '@/features/teacher/threadDetail/mutations/useUpdateChatRoomStatus';

--- a/src/features/teacher/threadDetail/mutations/useAnalyzeTeacherMessage.ts
+++ b/src/features/teacher/threadDetail/mutations/useAnalyzeTeacherMessage.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+
+type AnalyzeTeacherMessageParams = {
+  chatRoomId: number;
+  content: string;
+};
+
+export const useAnalyzeTeacherMessage = () => {
+  return useMutation({
+    mutationFn: ({ chatRoomId, content }: AnalyzeTeacherMessageParams) => {
+      return threadDetailApi.analyzeMessage(chatRoomId, content);
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/mutations/useReadChatRoom.ts
+++ b/src/features/teacher/threadDetail/mutations/useReadChatRoom.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { threadDetailApi } from '@/services/teacher/threadDetailApi';
-import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+import { threadQueryKeys } from '@/constants/threadQueryKeys';
 
 export const useReadChatRoom = (chatRoomId: number) => {
   const queryClient = useQueryClient();
@@ -9,7 +9,7 @@ export const useReadChatRoom = (chatRoomId: number) => {
     mutationFn: () => threadDetailApi.readRoom(chatRoomId),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: threadDetailQueryKeys.threadList(),
+        queryKey: threadQueryKeys.threadList(),
       });
     },
   });

--- a/src/features/teacher/threadDetail/mutations/useRecheckTeacherMessage.ts
+++ b/src/features/teacher/threadDetail/mutations/useRecheckTeacherMessage.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+
+type RecheckTeacherMessageParams = {
+  analysisId: number;
+  content: string;
+};
+
+export const useRecheckTeacherMessage = () => {
+  return useMutation({
+    mutationFn: ({ analysisId, content }: RecheckTeacherMessageParams) => {
+      return threadDetailApi.recheckMessage(analysisId, content);
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/mutations/useSaveAnalysisFeedback.ts
+++ b/src/features/teacher/threadDetail/mutations/useSaveAnalysisFeedback.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+
+type SaveAnalysisFeedbackParams = {
+  analysisId: number;
+  score: number;
+};
+
+export const useSaveAnalysisFeedback = () => {
+  return useMutation({
+    mutationFn: ({ analysisId, score }: SaveAnalysisFeedbackParams) => {
+      return threadDetailApi.saveAnalysisFeedback(analysisId, score);
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/mutations/useSaveRecommendationAdoption.ts
+++ b/src/features/teacher/threadDetail/mutations/useSaveRecommendationAdoption.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+
+export const useSaveRecommendationAdoption = () => {
+  return useMutation({
+    mutationFn: (analysisId: number) => {
+      return threadDetailApi.saveRecommendationAdoption(analysisId);
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/mutations/useSendTeacherMessage.ts
+++ b/src/features/teacher/threadDetail/mutations/useSendTeacherMessage.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { threadDetailApi } from '@/services/teacher/threadDetailApi';
-import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+import { threadQueryKeys } from '@/constants/threadQueryKeys';
 import type { SendTeacherMessageRequest } from '@/features/teacher/threadDetail/types';
 
 type SendTeacherMessageParams = {
@@ -17,7 +17,7 @@ export const useSendTeacherMessage = () => {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: threadDetailQueryKeys.threadList(),
+        queryKey: threadQueryKeys.threadList(),
       });
     },
   });

--- a/src/features/teacher/threadDetail/mutations/useUpdateChatRoomStatus.ts
+++ b/src/features/teacher/threadDetail/mutations/useUpdateChatRoomStatus.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { threadQueryKeys } from '@/constants/threadQueryKeys';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+import type { ThreadStatus } from '@/stores/threadStatusStore';
+
+type UpdateChatRoomStatusParams = {
+  chatRoomId: number;
+  status: ThreadStatus;
+};
+
+export const useUpdateChatRoomStatus = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ chatRoomId, status }: UpdateChatRoomStatusParams) => {
+      return threadDetailApi.updateStatus(chatRoomId, status);
+    },
+    onSuccess: (_, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: threadQueryKeys.detail(variables.chatRoomId),
+      });
+
+      void queryClient.invalidateQueries({
+        queryKey: threadQueryKeys.threadList(),
+      });
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/queries/index.ts
+++ b/src/features/teacher/threadDetail/queries/index.ts
@@ -1,1 +1,2 @@
 export { useChatMessagesQuery } from './useChatMessagesQuery';
+export { useChatRoomDetailQuery } from './useChatRoomDetailQuery';

--- a/src/features/teacher/threadDetail/queries/useChatMessagesQuery.ts
+++ b/src/features/teacher/threadDetail/queries/useChatMessagesQuery.ts
@@ -1,6 +1,6 @@
 import { useInfiniteQuery, useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { threadDetailApi } from '@/services/teacher/threadDetailApi';
-import { threadDetailQueryKeys } from '@/constants/threadDetailQueryKeys';
+import { threadQueryKeys } from '@/constants/threadQueryKeys';
 import { toMessageItem } from '@/features/teacher/threadDetail/lib';
 import type { MessageItem } from '@/features/teacher/threadDetail/types';
 
@@ -16,7 +16,7 @@ type ChatMessagesPage = {
 export const useChatMessagesQuery = (chatRoomId: number) => {
   const queryClient = useQueryClient();
   const isValidChatRoomId = Number.isFinite(chatRoomId) && chatRoomId > 0;
-  const queryKey = threadDetailQueryKeys.messages(chatRoomId);
+  const queryKey = threadQueryKeys.messages(chatRoomId);
 
   const query = useInfiniteQuery({
     queryKey,

--- a/src/features/teacher/threadDetail/queries/useChatRoomDetailQuery.ts
+++ b/src/features/teacher/threadDetail/queries/useChatRoomDetailQuery.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { threadQueryKeys } from '@/constants/threadQueryKeys';
+import { threadDetailApi } from '@/services/teacher/threadDetailApi';
+
+export const useChatRoomDetailQuery = (chatRoomId: number) => {
+  const isValidChatRoomId = Number.isFinite(chatRoomId) && chatRoomId > 0;
+
+  return useQuery({
+    queryKey: threadQueryKeys.detail(chatRoomId),
+    enabled: isValidChatRoomId,
+    queryFn: async () => {
+      const response = await threadDetailApi.getChatRoomDetail(chatRoomId);
+      const payload = response.data;
+
+      if (!payload) {
+        throw new Error('채팅방 데이터가 없습니다.');
+      }
+
+      return payload;
+    },
+  });
+};

--- a/src/features/teacher/threadDetail/types.ts
+++ b/src/features/teacher/threadDetail/types.ts
@@ -2,7 +2,7 @@ import type { ThreadStatus } from '@/stores/threadStatusStore';
 
 export type DetailLoadState = 'loading' | 'error' | 'success';
 
-export type AnalysisRiskLevel = 'SAFE' | 'UNSAFE' | 'LOW' | 'HIGH';
+export type AnalysisRiskLevel = 'SAFE' | 'UNSAFE';
 
 export type ChatRoomDetailData = {
   chatRoomId: number;
@@ -59,7 +59,7 @@ export type AnalyzeTeacherMessageResponse = {
   data?: {
     analysisId: number;
     riskLevel: AnalysisRiskLevel;
-    recommendedMessage: string;
+    recommendedMessage: string | null;
   } | null;
 };
 
@@ -93,13 +93,14 @@ export type AnalysisFeedbackResponse = {
   success: boolean;
   code: number;
   message: string;
+  data?: Record<string, never> | null;
 };
 
 export type RecommendationAdoptionResponse = {
   success: boolean;
   code: number;
   message: string;
-  data?: null;
+  data?: Record<string, never> | null;
 };
 
 export type UpdateChatRoomStatusResponse = {
@@ -115,8 +116,9 @@ export type UpdateChatRoomStatusResponse = {
 export type AnalysisResult = {
   analysisId: number;
   riskLevel: AnalysisRiskLevel;
-  summary: string;
-  recommendedReply?: string | null;
+  title: string;
+  description: string;
+  recommendedMessage?: string | null;
 };
 
 export type MessageItem = {

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -141,9 +141,9 @@ export const TeacherThreadDetailPage = () => {
 
               <LowRiskCard $risk={isUnsafeRisk ? 'high' : 'low'}>
                 <LowRiskTitle $risk={isUnsafeRisk ? 'high' : 'low'}>
-                  {isUnsafeRisk ? '오해가 발생할 수 있는 메시지예요' : '문제 없는 메시지예요'}
+                  {analysisResult.title}
                 </LowRiskTitle>
-                <LowRiskDescription>{analysisResult.summary}</LowRiskDescription>
+                <LowRiskDescription>{analysisResult.description}</LowRiskDescription>
               </LowRiskCard>
 
               <FeedbackSection>
@@ -196,7 +196,7 @@ export const TeacherThreadDetailPage = () => {
                 <RecommendSection>
                   <RecommendTitle>AI 추천 답변</RecommendTitle>
                   <RecommendCard>
-                    {analysisResult.recommendedReply ||
+                    {analysisResult.recommendedMessage ||
                       '학부모님, 안내해주신 내용을 바탕으로 확인 후 정확하게 다시 안내드리겠습니다.'}
                   </RecommendCard>
                   <InlineButton


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#50 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 채팅방 화면의 서버 상태 관리 로직을 TanStack Query 기반으로 분리
- 채팅방 관련 query/mutation hook을 기능별로 분리
- 메시지 작성/분석/전송, 분석 피드백, 처리 상태 변경, 포커스 복귀 시 메시지 갱신 로직을 별도 custom hook으로 분리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- threadDetailQueryKeys를 threadQueryKeys로 변경하고 query key 구조 정리
- 채팅방 상세 조회 로직을 useChatRoomDetailQuery로 분리
- 메시지 목록 조회 query 구조 점검 및 정리
- 읽음 처리 readRoom mutation 분리 및 수신함 목록 invalidate 처리
- 채팅방 상태 변경 updateStatus mutation 분리
- 교사 메시지 분석 analyzeMessage mutation 분리
- 교사 메시지 재분석 recheckMessage mutation 분리
- 교사 메시지 전송 sendMessage mutation 구조 정리
- 추천문장 채택 saveRecommendationAdoption mutation 분리
- 분석 피드백 저장 saveAnalysisFeedback mutation 분리
- 메시지 작성/분석/전송 로직을 useThreadComposer로 분리
- 분석 피드백 로직을 useThreadAnalysisFeedback으로 분리
- 처리 상태 변경 로직을 useThreadStatusControl로 분리
- 포커스 복귀 시 메시지 갱신 로직을 useRefreshChatMessagesOnFocus로 분리
- useThreadDetail 내부 서버 상태 로직 제거 및 hook 조합 구조로 정리
- 분석 결과 문구를 mapper에서 title, description으로 매핑하도록 정리
- 위험도 타입을 실제 응답 기준인 SAFE, UNSAFE로 정리
- 메시지 전송 중에는 어시스턴트 패널의 분석 로딩 상태가 표시되는 문제를 분석 요청 상태와 전송 요청 상태 분리해 해결

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
