### PR TITLE
[FIX] 관리자 AI 모델 화면 오류 및 액션 피드백 수정 #53

### DIFF
--- a/src/components/admin/aiModel/ModelRetrainingSection.tsx
+++ b/src/components/admin/aiModel/ModelRetrainingSection.tsx
@@ -5,29 +5,48 @@ import { Alert } from '@/components/common/Alert';
 import { Loader } from '@/components/common/Loader';
 import { SectionEmptyState } from '@/components/common/SectionEmptyState';
 import { InfoFieldGrid } from '@/components/admin/aiModel/InfoFieldGrid';
+import { ProgressBar } from '@/components/admin/aiModel/ProgressBar';
 import { useModelRetraining } from '@/features/admin/aiModel/hooks/useModelRetraining';
+import { getModelTrainingStatusText } from '@/features/admin/aiModel/lib/modelTrainingStatus';
 import { formatAiModelDateTime } from '@/utils/formatDateTime';
 import { IcDashboard, IcRefresh } from '@/icons';
 
 type RetrainingStatusAlertProps = {
   isRetrainingInProgress: boolean;
+  isRetrainingPaused: boolean;
   isRetrainingFailed: boolean;
   isPerformanceDegraded: boolean;
   retrainError: boolean;
+  progressPercent: number;
 };
 
 const RetrainingStatusAlert = ({
   isRetrainingInProgress,
+  isRetrainingPaused,
   isRetrainingFailed,
   isPerformanceDegraded,
   retrainError,
+  progressPercent,
 }: RetrainingStatusAlertProps) => {
   if (isRetrainingInProgress) {
     return (
+      <RetrainingProgressArea>
+        <Alert
+          variant="success"
+          title="모델 재학습을 진행 중이에요"
+          description="재학습이 완료되면 최신 모델 정보와 성능 평가가 갱신돼요."
+        />
+        <ProgressBar label="진행률" value={progressPercent} />
+      </RetrainingProgressArea>
+    );
+  }
+
+  if (isRetrainingPaused) {
+    return (
       <Alert
-        variant="success"
-        title="모델 재학습을 진행 중이에요"
-        description="재학습이 완료되면 최신 모델 정보와 성능 평가가 갱신돼요."
+        variant="warning"
+        title="모델 재학습이 일시중지되었어요"
+        description="재학습 상태를 확인한 뒤 다시 실행해주세요."
       />
     );
   }
@@ -61,10 +80,12 @@ const RetrainingStatusAlert = ({
 export const ModelRetrainingSection = () => {
   const {
     latestModelInfo,
+    progressPercent,
     isLoading,
     isError,
     isRetraining,
     isRetrainingInProgress,
+    isRetrainingPaused,
     isRetrainingFailed,
     isPerformanceDegraded,
     retrainError,
@@ -125,7 +146,7 @@ export const ModelRetrainingSection = () => {
     },
     {
       label: '현재 상태',
-      value: latestModelInfo.status || '-',
+      value: getModelTrainingStatusText(latestModelInfo.status),
     },
     {
       label: '마지막 학습',
@@ -143,9 +164,11 @@ export const ModelRetrainingSection = () => {
         <RetrainingContainer>
           <RetrainingStatusAlert
             isRetrainingInProgress={isRetrainingInProgress}
+            isRetrainingPaused={isRetrainingPaused}
             isRetrainingFailed={isRetrainingFailed}
             isPerformanceDegraded={isPerformanceDegraded}
             retrainError={retrainError}
+            progressPercent={progressPercent}
           />
 
           <InfoFieldGrid fields={retrainingInfoFields} />
@@ -159,4 +182,10 @@ const RetrainingContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 24px;
+`;
+
+const RetrainingProgressArea = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 `;

--- a/src/components/admin/aiModel/ModelTrainingHistorySection.tsx
+++ b/src/components/admin/aiModel/ModelTrainingHistorySection.tsx
@@ -8,6 +8,7 @@ import { TrainingHistoryChart } from '@/components/admin/aiModel/TrainingHistory
 import { useTrainingHistory } from '@/features/admin/aiModel/hooks/useTrainingHistory';
 import { formatAiModelDateTime } from '@/utils/formatDateTime';
 import { IcDashboard } from '@/icons';
+import { formatF1Score } from '@/features/admin/aiModel/lib/formatF1Score';
 
 export const ModelTrainingHistorySection = () => {
   const {
@@ -82,7 +83,7 @@ export const ModelTrainingHistorySection = () => {
                     <TableCell>{formatAiModelDateTime(item.trainedAt)}</TableCell>
                     <TableCell>{item.version || '-'}</TableCell>
                     <TableCell>{item.datasetVersion || '-'}</TableCell>
-                    <TableCell>{item.f1Score.toFixed(2)}</TableCell>
+                    <TableCell>{formatF1Score(item.f1Score)}</TableCell>
                     <TableCell>{item.status || '-'}</TableCell>
                   </tr>
                 ))}

--- a/src/components/admin/aiModel/TrainingHistoryChart.tsx
+++ b/src/components/admin/aiModel/TrainingHistoryChart.tsx
@@ -22,8 +22,8 @@ type TrainingHistoryChartData = {
   f1Score: number;
 };
 
-const isValidF1Score = (value: TrainingHistoryItem['f1Score']): value is number => {
-  return Number.isFinite(value);
+const isValidF1Score = (value: unknown): value is number => {
+  return typeof value === 'number' && Number.isFinite(value);
 };
 
 export const TrainingHistoryChart = ({ data }: TrainingHistoryChartProps) => {
@@ -31,12 +31,21 @@ export const TrainingHistoryChart = ({ data }: TrainingHistoryChartProps) => {
 
   const chartData: TrainingHistoryChartData[] = [...data]
     .reverse()
-    .filter(item => isValidF1Score(item.f1Score))
-    .map((item, index) => ({
-      chartId: `${item.version}-${item.trainedAt}-${index}`,
-      version: item.version || '-',
-      f1Score: item.f1Score,
-    }));
+    .reduce<TrainingHistoryChartData[]>((acc, item, index) => {
+      const f1Score = item.f1Score;
+
+      if (!isValidF1Score(f1Score)) {
+        return acc;
+      }
+
+      acc.push({
+        chartId: `${item.version}-${item.trainedAt}-${index}`,
+        version: item.version || '-',
+        f1Score,
+      });
+
+      return acc;
+    }, []);
 
   return (
     <ResponsiveContainer width="100%" height={260}>

--- a/src/components/admin/aiModel/TrainingHistoryChart.tsx
+++ b/src/components/admin/aiModel/TrainingHistoryChart.tsx
@@ -10,19 +10,33 @@ import {
 } from 'recharts';
 import type { TrainingHistoryItem } from '@/services/admin/aiModelApi';
 import type { ValueType } from 'recharts/types/component/DefaultTooltipContent';
+import { formatF1Score } from '@/features/admin/aiModel/lib/formatF1Score';
 
 type TrainingHistoryChartProps = {
   data: TrainingHistoryItem[];
 };
 
+type TrainingHistoryChartData = {
+  chartId: string;
+  version: string;
+  f1Score: number;
+};
+
+const isValidF1Score = (value: TrainingHistoryItem['f1Score']): value is number => {
+  return Number.isFinite(value);
+};
+
 export const TrainingHistoryChart = ({ data }: TrainingHistoryChartProps) => {
   const theme = useTheme();
 
-  const chartData = [...data].reverse().map((item, index) => ({
-    chartId: `${item.version}-${item.trainedAt}-${index}`,
-    version: item.version,
-    f1Score: item.f1Score,
-  }));
+  const chartData: TrainingHistoryChartData[] = [...data]
+    .reverse()
+    .filter(item => isValidF1Score(item.f1Score))
+    .map((item, index) => ({
+      chartId: `${item.version}-${item.trainedAt}-${index}`,
+      version: item.version || '-',
+      f1Score: item.f1Score,
+    }));
 
   return (
     <ResponsiveContainer width="100%" height={260}>
@@ -49,9 +63,7 @@ export const TrainingHistoryChart = ({ data }: TrainingHistoryChartProps) => {
           axisLine={false}
           width={36}
         />
-        <Tooltip
-          formatter={(value: ValueType | undefined) => [Number(value).toFixed(2), 'F1-score']}
-        />
+        <Tooltip formatter={(value: ValueType | undefined) => [formatF1Score(value), 'F1-score']} />
         <Area
           type="monotone"
           dataKey="f1Score"

--- a/src/features/admin/aiModel/constants/aiModelQueryKeys.ts
+++ b/src/features/admin/aiModel/constants/aiModelQueryKeys.ts
@@ -6,4 +6,5 @@ export const aiModelQueryKeys = {
   trainingHistory: (page: number, size: number) =>
     [...aiModelQueryKeys.all, 'training-history', page, size] as const,
   tokenUsage: () => [...aiModelQueryKeys.all, 'token-usage'] as const,
+  trainingJob: (jobId: string) => [...aiModelQueryKeys.all, 'trainingJob', jobId] as const,
 };

--- a/src/features/admin/aiModel/hooks/useModelRetraining.ts
+++ b/src/features/admin/aiModel/hooks/useModelRetraining.ts
@@ -1,37 +1,43 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useToast } from '@/hooks/useToast';
 import { latestModelInfoQueryOptions } from '@/features/admin/aiModel/queries/modelInfo';
 import { latestEvaluationQueryOptions } from '@/features/admin/aiModel/queries/modelEvaluation';
 import { retrainModel } from '@/features/admin/aiModel/mutations/modelRetraining';
+import { trainingJobQueryOptions } from '@/features/admin/aiModel/queries/modelRetraining';
 import { aiModelQueryKeys } from '@/features/admin/aiModel/constants/aiModelQueryKeys';
 import { PERFORMANCE_DEGRADATION_THRESHOLD } from '@/features/admin/aiModel/constants/modelEvaluation';
+import {
+  isRetrainingCompletedStatus,
+  isRetrainingFailedStatus,
+  isRetrainingPausedStatus,
+  isRetrainingProgressStatus,
+} from '@/features/admin/aiModel/lib/modelTrainingStatus';
 
-const MODEL_INFO_REFETCH_INTERVAL = 3000;
+const RETRAINING_REFETCH_INTERVAL = 2000;
 
-const isTrainingInProgressStatus = (status?: string | null) => {
-  return status === 'queued' || status === 'running';
+const getSafeProgressPercent = (progressPercent?: number | null) => {
+  if (typeof progressPercent !== 'number' || !Number.isFinite(progressPercent)) {
+    return 0;
+  }
+
+  return Math.min(100, Math.max(0, progressPercent));
 };
 
 export const useModelRetraining = () => {
   const { showToast } = useToast();
   const queryClient = useQueryClient();
 
-  const isRetrainTriggeredRef = useRef(false);
-  const retrainBaseJobIdRef = useRef<string | null>(null);
+  const [retrainingJobId, setRetrainingJobId] = useState<string | null>(null);
+
+  const notifiedCompletedJobIdRef = useRef<string | null>(null);
+  const notifiedFailedJobIdRef = useRef<string | null>(null);
 
   const {
     data: latestModelInfo,
     isLoading: isModelInfoLoading,
     isError: isModelInfoError,
-  } = useQuery({
-    ...latestModelInfoQueryOptions(),
-    refetchInterval: query => {
-      const status = query.state.data?.status;
-
-      return isTrainingInProgressStatus(status) ? MODEL_INFO_REFETCH_INTERVAL : false;
-    },
-  });
+  } = useQuery(latestModelInfoQueryOptions());
 
   const {
     data: latestEvaluation,
@@ -39,61 +45,101 @@ export const useModelRetraining = () => {
     isError: isEvaluationError,
   } = useQuery(latestEvaluationQueryOptions());
 
-  const status = latestModelInfo?.status;
-  const jobId = latestModelInfo?.jobId;
+  const { data: retrainingJob, isError: isRetrainingJobError } = useQuery({
+    ...trainingJobQueryOptions(retrainingJobId ?? ''),
+    enabled: Boolean(retrainingJobId),
+    refetchInterval: query => {
+      const status = query.state.data?.status;
 
-  const isRetrainingInProgress = isTrainingInProgressStatus(status);
-  const isRetrainingFailed = status === 'failed';
+      return isRetrainingProgressStatus(status) ? RETRAINING_REFETCH_INTERVAL : false;
+    },
+  });
+
+  const retrainingStatus = retrainingJob?.status;
+  const progressPercent = getSafeProgressPercent(retrainingJob?.progressPercent);
+
+  const isWaitingRetrainingJob =
+    Boolean(retrainingJobId) && !retrainingJob && !isRetrainingJobError;
+
+  const isRetrainingInProgress =
+    isWaitingRetrainingJob || isRetrainingProgressStatus(retrainingStatus);
+
+  const isRetrainingPaused = isRetrainingPausedStatus(retrainingStatus);
+  const isRetrainingFailed = isRetrainingFailedStatus(retrainingStatus) || isRetrainingJobError;
+  const isRetrainingCompleted = isRetrainingCompletedStatus(retrainingStatus);
 
   const isPerformanceDegraded =
     latestEvaluation?.status === 'completed' &&
     latestEvaluation.f1Score < PERFORMANCE_DEGRADATION_THRESHOLD;
 
   useEffect(() => {
-    if (
-      isRetrainTriggeredRef.current &&
-      status === 'completed' &&
-      jobId &&
-      jobId !== retrainBaseJobIdRef.current
-    ) {
-      showToast('모델 재학습이 완료되었어요', 'success');
-      isRetrainTriggeredRef.current = false;
-
-      void queryClient.invalidateQueries({
-        queryKey: aiModelQueryKeys.latestModelInfo(),
-      });
-
-      void queryClient.invalidateQueries({
-        queryKey: aiModelQueryKeys.latestEvaluation(),
-      });
+    if (!retrainingJobId || !isRetrainingCompleted) {
+      return;
     }
 
-    if (isRetrainTriggeredRef.current && status === 'failed') {
-      isRetrainTriggeredRef.current = false;
+    if (notifiedCompletedJobIdRef.current === retrainingJobId) {
+      return;
     }
-  }, [jobId, queryClient, showToast, status]);
+
+    notifiedCompletedJobIdRef.current = retrainingJobId;
+    notifiedFailedJobIdRef.current = null;
+
+    showToast('모델 재학습이 완료되었어요', 'success');
+
+    void queryClient.invalidateQueries({
+      queryKey: aiModelQueryKeys.latestModelInfo(),
+    });
+
+    void queryClient.invalidateQueries({
+      queryKey: aiModelQueryKeys.latestEvaluation(),
+    });
+
+    void queryClient.invalidateQueries({
+      queryKey: aiModelQueryKeys.trainingHistory(1, 20),
+    });
+  }, [isRetrainingCompleted, queryClient, retrainingJobId, showToast]);
+
+  useEffect(() => {
+    if (!retrainingJobId || !isRetrainingFailed) {
+      return;
+    }
+
+    if (notifiedFailedJobIdRef.current === retrainingJobId) {
+      return;
+    }
+
+    notifiedFailedJobIdRef.current = retrainingJobId;
+    showToast('모델 재학습에 실패했어요', 'error');
+  }, [isRetrainingFailed, retrainingJobId, showToast]);
 
   const retrainMutation = useMutation({
     mutationFn: retrainModel,
-    onSuccess: async () => {
-      isRetrainTriggeredRef.current = true;
+    onSuccess: response => {
+      const nextJobId = response.jobId;
 
-      showToast('모델 재학습을 시작했어요', 'success');
+      if (!nextJobId) {
+        showToast('재학습 작업 정보를 확인할 수 없어요', 'error');
+        return;
+      }
 
-      await queryClient.invalidateQueries({
-        queryKey: aiModelQueryKeys.latestModelInfo(),
-      });
+      notifiedCompletedJobIdRef.current = null;
+      notifiedFailedJobIdRef.current = null;
 
-      await queryClient.invalidateQueries({
-        queryKey: aiModelQueryKeys.latestEvaluation(),
-      });
+      setRetrainingJobId(nextJobId);
 
-      await queryClient.refetchQueries({
-        queryKey: aiModelQueryKeys.latestModelInfo(),
+      if (isRetrainingProgressStatus(response.status)) {
+        showToast('모델 재학습을 시작했어요', 'success');
+      } else if (isRetrainingCompletedStatus(response.status)) {
+        showToast('최근 재학습이 이미 완료되었어요', 'success');
+      } else if (isRetrainingFailedStatus(response.status)) {
+        showToast('최근 재학습이 실패 상태예요', 'error');
+      }
+
+      void queryClient.invalidateQueries({
+        queryKey: aiModelQueryKeys.trainingJob(nextJobId),
       });
     },
     onError: () => {
-      isRetrainTriggeredRef.current = false;
       showToast('모델 재학습 요청에 실패했어요', 'error');
     },
   });
@@ -103,7 +149,6 @@ export const useModelRetraining = () => {
       return;
     }
 
-    retrainBaseJobIdRef.current = latestModelInfo?.jobId ?? null;
     retrainMutation.reset();
     retrainMutation.mutate();
   };
@@ -111,12 +156,18 @@ export const useModelRetraining = () => {
   return {
     latestModelInfo,
     latestEvaluation,
+    retrainingJob,
+    progressPercent,
+
     isLoading: isModelInfoLoading || isEvaluationLoading,
     isError: isModelInfoError || isEvaluationError,
+
+    isRetraining: retrainMutation.isPending || isRetrainingInProgress,
     isRetrainingInProgress,
+    isRetrainingPaused,
     isRetrainingFailed,
     isPerformanceDegraded,
-    isRetraining: retrainMutation.isPending || isRetrainingInProgress,
+
     retrainError: retrainMutation.isError,
     handleRetrain,
   };

--- a/src/features/admin/aiModel/lib/formatF1Score.ts
+++ b/src/features/admin/aiModel/lib/formatF1Score.ts
@@ -1,0 +1,13 @@
+import type { ValueType } from 'recharts/types/component/DefaultTooltipContent';
+
+export const isValidF1Score = (score: unknown): score is number => {
+  return typeof score === 'number' && Number.isFinite(score);
+};
+
+export const formatF1Score = (score: ValueType | number | null | undefined) => {
+  if (!isValidF1Score(score)) {
+    return '-';
+  }
+
+  return score.toFixed(2);
+};

--- a/src/features/admin/aiModel/lib/modelTrainingStatus.ts
+++ b/src/features/admin/aiModel/lib/modelTrainingStatus.ts
@@ -1,0 +1,37 @@
+import type { TrainingJobStatus } from '@/services/admin/aiModelApi';
+
+export const MODEL_TRAINING_STATUS_TEXT = {
+  QUEUED: '대기 중',
+  RUNNING: '재학습 중',
+  PAUSED: '일시중지',
+  COMPLETED: '완료',
+  FAILED: '실패',
+} satisfies Record<TrainingJobStatus, string>;
+
+export const getModelTrainingStatusText = (status?: TrainingJobStatus | string | null) => {
+  if (!status) {
+    return '-';
+  }
+
+  if (status in MODEL_TRAINING_STATUS_TEXT) {
+    return MODEL_TRAINING_STATUS_TEXT[status as TrainingJobStatus];
+  }
+
+  return status;
+};
+
+export const isRetrainingProgressStatus = (status?: TrainingJobStatus | null) => {
+  return status === 'QUEUED' || status === 'RUNNING';
+};
+
+export const isRetrainingPausedStatus = (status?: TrainingJobStatus | null) => {
+  return status === 'PAUSED';
+};
+
+export const isRetrainingCompletedStatus = (status?: TrainingJobStatus | null) => {
+  return status === 'COMPLETED';
+};
+
+export const isRetrainingFailedStatus = (status?: TrainingJobStatus | null) => {
+  return status === 'FAILED';
+};

--- a/src/features/admin/aiModel/queries/modelRetraining.ts
+++ b/src/features/admin/aiModel/queries/modelRetraining.ts
@@ -1,0 +1,15 @@
+import { queryOptions } from '@tanstack/react-query';
+import { aiModelApi } from '@/services/admin/aiModelApi';
+import { aiModelQueryKeys } from '@/features/admin/aiModel/constants/aiModelQueryKeys';
+
+export const trainingJobQueryOptions = (jobId: string) => {
+  return queryOptions({
+    queryKey: aiModelQueryKeys.trainingJob(jobId),
+    queryFn: async () => {
+      const response = await aiModelApi.getTrainingJob(jobId);
+
+      return response.data;
+    },
+    enabled: Boolean(jobId),
+  });
+};

--- a/src/services/admin/aiModelApi.ts
+++ b/src/services/admin/aiModelApi.ts
@@ -1,13 +1,15 @@
 import type { ApiResponse } from '@/types/apiResponse';
 import { apiClient } from '@/services/http/apiClient';
 
+export type TrainingJobStatus = 'QUEUED' | 'RUNNING' | 'PAUSED' | 'COMPLETED' | 'FAILED';
+
 export type LatestModelInfo = {
   jobId: string;
   modelName: string;
   modelVersion: string;
   datasetVersion: string;
-  status: string;
-  lastTrainedAt: string;
+  status: TrainingJobStatus;
+  lastTrainedAt: string | null;
 };
 
 export type LatestModelEvaluationStatus = 'queued' | 'running' | 'completed' | 'failed';
@@ -18,7 +20,7 @@ export type LatestModelEvaluation = {
   recall: number;
   f1Score: number;
   status: LatestModelEvaluationStatus;
-  progressPercent: number;
+  progressPercent: number | null;
   passed: boolean;
   version: string;
   resultCode: number;
@@ -32,7 +34,7 @@ export type RerunModelEvaluationRequest = {
 
 export type RerunModelEvaluationResult = {
   evaluationId: string;
-  status: string;
+  status: LatestModelEvaluationStatus;
   resultCode: number;
   resultMessage: string;
   contentType: string;
@@ -42,15 +44,26 @@ export type RerunModelEvaluationResult = {
 
 export type RetrainModelResult = {
   jobId: string;
-  status: string;
+  status: TrainingJobStatus;
+};
+
+export type TrainingJobDetail = {
+  jobId: string;
+  modelName: string;
+  modelVersion: string;
+  datasetVersion: string;
+  status: TrainingJobStatus;
+  progressPercent: number | null;
+  startedAt: string | null;
+  finishedAt: string | null;
 };
 
 export type TrainingHistoryItem = {
   trainedAt: string;
   version: string;
   datasetVersion: string;
-  f1Score: number;
-  status: string;
+  f1Score: number | null;
+  status: TrainingJobStatus;
 };
 
 export type TrainingHistory = {
@@ -85,6 +98,7 @@ export type LatestModelInfoResponse = ApiResponse<LatestModelInfo | null>;
 export type LatestModelEvaluationResponse = ApiResponse<LatestModelEvaluation | null>;
 export type RerunModelEvaluationResponse = ApiResponse<RerunModelEvaluationResult | null>;
 export type RetrainModelResponse = ApiResponse<RetrainModelResult | null>;
+export type TrainingJobDetailResponse = ApiResponse<TrainingJobDetail | null>;
 export type TrainingHistoryResponse = ApiResponse<TrainingHistory>;
 
 export const aiModelApi = {
@@ -116,6 +130,14 @@ export const aiModelApi = {
 
   retrainModel: async () => {
     const { data } = await apiClient.post<RetrainModelResponse>('/admin/retraining');
+
+    return data;
+  },
+
+  getTrainingJob: async (jobId: string) => {
+    const { data } = await apiClient.get<TrainingJobDetailResponse>(
+      `/admin/training-jobs/${jobId}`
+    );
 
     return data;
   },


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#53 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 관리자 AI 모델 화면에서 학습 이력의 F1-score 값이 비어 있을 때 화면이 깨지는 문제 수정
- 재학습 실행 후 진행 상태를 명확히 확인할 수 있도록 재학습 작업 상태 조회 query 추가
- 진행 중 alert, progress bar, 버튼 비활성화 처리

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- 학습 이력 화면에서 F1-score가 null일 때 toFixed 호출로 화면이 깨지는 문제 수정
- F1-score 포맷팅 유틸 추가
- 학습 이력 테이블에서 유효하지 않은 F1-score는 대체값으로 표시
- 학습 이력 차트에서 유효하지 않은 F1-score 항목 제외
- 재학습 작업 상태 조회 query 추가
- 백엔드 재학습 상태 응답값 기준으로 상태 분기 처리
- 재학습 진행 중 alert와 progress bar 표시
- 재학습 진행률 값이 없을 때 0으로 안전 처리
- 재학습 진행 중 재학습 실행 버튼 비활성화 처리
- 재학습 상태 표시 문구 매핑 추가
- 재학습 완료/실패 시 토스트 피드백 처리
- 재학습 완료 후 최신 모델 정보, 성능 평가, 학습 이력 query 갱신 처리

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
