### PR TITLE
[REFACTOR] 교사 회원가입 플로우 및 인증 검증 구조, 상태 복구 개선 #60

### DIFF
--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -37,6 +37,8 @@ export const TextField = ({
 const FieldContainer = styled.div`
   display: flex;
   flex-direction: column;
+  width: 100%;
+  min-width: 0;
   gap: 8px;
 `;
 

--- a/src/features/auth/components/TeacherSignUpForm.tsx
+++ b/src/features/auth/components/TeacherSignUpForm.tsx
@@ -173,6 +173,7 @@ export const TeacherSignUpForm = ({
 const SignUpCard = styled.section`
   display: flex;
   flex-direction: column;
+  width: 100%;
   max-width: 441px;
   background: ${({ theme }) => theme.colors.background.bg1};
   box-shadow: ${({ theme }) => theme.colors.shadow.modal};
@@ -210,7 +211,8 @@ const SignUpHeaderTextArea = styled.div`
 
 const Title = styled.h1`
   text-align: center;
-  ${({ theme }) => theme.fonts.title2};
+  ${({ theme }) => theme.fonts.title3};
+  font-weight: bold;
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
@@ -218,7 +220,7 @@ const Description = styled.p`
   text-align: center;
   white-space: pre-line;
   ${({ theme }) => theme.fonts.body3};
-  color: ${({ theme }) => theme.colors.text.text3};
+  color: ${({ theme }) => theme.colors.text.text1};
 `;
 
 const SignUpFormSection = styled.form`
@@ -230,7 +232,7 @@ const SignUpFormSection = styled.form`
 const SignUpBodySection = styled.div`
   display: flex;
   flex-direction: column;
-  width: min(100%, 361px);
+  width: 100%;
   gap: 16px;
 `;
 
@@ -246,7 +248,7 @@ const ClassCodeCard = styled.div`
   align-items: center;
   width: 100%;
   border-radius: 14px;
-  border: 1px solid ${({ theme }) => theme.colors.border.border1};
+  border: 1px solid ${({ theme }) => theme.colors.brand.primary};
   background: ${({ theme }) => theme.colors.background.bg4};
   padding: 18px 14px;
   gap: 10px;
@@ -254,18 +256,19 @@ const ClassCodeCard = styled.div`
 
 const ClassLabel = styled.p`
   ${({ theme }) => theme.fonts.caption};
+  font-weight: 600;
   color: ${({ theme }) => theme.colors.brand.dark};
 `;
 
 const ClassCode = styled.p`
   ${({ theme }) => theme.fonts.title2};
-  letter-spacing: 0.02em;
+  font-weight: 700;
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
 const SignUpActionSection = styled.div`
   display: flex;
   flex-direction: column;
-  width: min(100%, 361px);
+  width: 100%;
   gap: 12px;
 `;

--- a/src/features/auth/components/TeacherSignUpForm.tsx
+++ b/src/features/auth/components/TeacherSignUpForm.tsx
@@ -1,9 +1,15 @@
 import styled from '@emotion/styled';
+import { useTheme } from '@emotion/react';
+import type { ComponentProps } from 'react';
 import { InlineButton } from '@/components/common/InlineButton';
 import { TextField } from '@/components/common/TextField';
-import { IcCheck, IcCopy, IcInfo, IcSparkles } from '@/icons';
+import { IconButton } from '@/components/common/IconButton';
+import { Alert } from '@/components/common/Alert';
+import { IconBadge } from '@/components/common/IconBadge';
 import type { AuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
 import type { SignUpStep } from '@/features/auth/hooks/useTeacherSignUpForm';
+import { IcCopy, IcLogout } from '@/icons';
+import { TEACHER_SIGN_UP_STEP_CONTENT } from '@/features/auth/constants/signupSteps';
 
 type TeacherSignUpFormProps = {
   teacherName: string;
@@ -17,19 +23,17 @@ type TeacherSignUpFormProps = {
     classNumber?: string;
   };
   globalError: AuthErrorMessage | null;
-  isSubmitting: boolean;
-  isCreatingClassCode: boolean;
-  isSignUpEnabled: boolean;
+  isSignUpActionDisabled: boolean;
   step: SignUpStep;
   generatedClassCode: string;
   setTeacherName: (value: string) => void;
   setSchoolName: (value: string) => void;
   setGrade: (value: string) => void;
   setClassNumber: (value: string) => void;
-  handleSubmit: React.FormEventHandler<HTMLFormElement>;
-  handleOpenClassCodeModal: () => void | Promise<void>;
+  handleLogout: () => void;
+  handleSubmit: NonNullable<ComponentProps<'form'>['onSubmit']>;
+  handleSignUpAction: () => void | Promise<void>;
   handleCopyClassCode: () => void | Promise<void>;
-  handleGoToInbox: () => void | Promise<void>;
 };
 
 export const TeacherSignUpForm = ({
@@ -39,211 +43,175 @@ export const TeacherSignUpForm = ({
   classNumber,
   fieldErrors,
   globalError,
-  isSubmitting,
-  isCreatingClassCode,
-  isSignUpEnabled,
+  isSignUpActionDisabled,
   step,
   generatedClassCode,
   setTeacherName,
   setSchoolName,
   setGrade,
   setClassNumber,
+  handleLogout,
   handleSubmit,
-  handleOpenClassCodeModal,
+  handleSignUpAction,
   handleCopyClassCode,
-  handleGoToInbox,
 }: TeacherSignUpFormProps) => {
-  const progressRatio = step === 'CLASS_CODE_READY' ? 1 : step === 'SIGN_UP_SUCCESS' ? 0.66 : 0.33;
+  const theme = useTheme();
+  const {
+    progressRatio,
+    iconBadge: Icon,
+    title,
+    description,
+    actionLabel,
+  } = TEACHER_SIGN_UP_STEP_CONTENT[step];
 
   return (
-    <PageContainer>
-      <Card>
-        <ProgressTrack aria-hidden>
-          <ProgressFill style={{ width: `${progressRatio * 100}%` }} />
-        </ProgressTrack>
+    <SignUpPageContainer>
+      <SignUpContent>
+        {step === 'FORM' && (
+          <IconButton
+            icon={IcLogout}
+            variant="plain"
+            onClick={handleLogout}
+            accessibilityLabel="로그아웃"
+          />
+        )}
+        <SignUpCard>
+          <ProgressTrack aria-hidden>
+            <ProgressFill style={{ width: `${progressRatio * 100}%` }} />
+          </ProgressTrack>
 
-        {step === 'FORM' ? (
-          <>
-            <Title>교사 정보 입력</Title>
-            <Description>가입을 위해 선생님의 정보를 입력해주세요.</Description>
-
-            <SignUpFormSection onSubmit={handleSubmit}>
-              <TextField
-                id="teacherName"
-                name="teacherName"
-                label="이름"
-                isRequired
-                value={teacherName}
-                onChange={event => setTeacherName(event.target.value)}
-                placeholder="홍길동"
-                errorMessage={fieldErrors.teacherName}
-              />
-
-              <TextField
-                id="schoolName"
-                name="schoolName"
-                label="학교명"
-                isRequired
-                value={schoolName}
-                onChange={event => setSchoolName(event.target.value)}
-                placeholder="한국초등학교"
-                errorMessage={fieldErrors.schoolName}
-              />
-
-              <InlineTwoColumn>
+          <SignUpFormSection onSubmit={handleSubmit}>
+            <SignUpHeaderSection>
+              {Icon && (
+                <IconBadge
+                  icon={Icon}
+                  bgColor={theme.colors.background.bg4}
+                  color={theme.colors.brand.dark}
+                />
+              )}
+              <SignUpHeaderTextArea>
+                <Title>{title}</Title>
+                <Description>{description}</Description>
+              </SignUpHeaderTextArea>
+            </SignUpHeaderSection>
+            {step === 'FORM' ? (
+              <SignUpBodySection>
                 <TextField
-                  id="grade"
-                  name="grade"
-                  inputMode="numeric"
-                  label="학년"
+                  id="teacherName"
+                  name="teacherName"
+                  label="이름"
                   isRequired
-                  value={grade}
-                  onChange={event => setGrade(event.target.value)}
-                  placeholder="3"
-                  errorMessage={fieldErrors.grade}
+                  value={teacherName}
+                  onChange={event => setTeacherName(event.target.value)}
+                  placeholder="홍길동"
+                  errorMessage={fieldErrors.teacherName}
                 />
 
                 <TextField
-                  id="classNumber"
-                  name="classNumber"
-                  inputMode="numeric"
-                  label="반"
+                  id="schoolName"
+                  name="schoolName"
+                  label="학교명"
                   isRequired
-                  value={classNumber}
-                  onChange={event => setClassNumber(event.target.value)}
-                  placeholder="2"
-                  errorMessage={fieldErrors.classNumber}
+                  value={schoolName}
+                  onChange={event => setSchoolName(event.target.value)}
+                  placeholder="한국초등학교"
+                  errorMessage={fieldErrors.schoolName}
                 />
-              </InlineTwoColumn>
 
-              {globalError ? (
-                <ErrorBox role="alert">
-                  <ErrorIcon>
-                    <IcInfo />
-                  </ErrorIcon>
-                  <ErrorMessageGroup>
-                    <ErrorTitle>{globalError.title}</ErrorTitle>
-                    <ErrorDescription>{globalError.description}</ErrorDescription>
-                  </ErrorMessageGroup>
-                </ErrorBox>
-              ) : null}
+                <InlineTwoColumn>
+                  <TextField
+                    id="grade"
+                    name="grade"
+                    inputMode="numeric"
+                    label="학년"
+                    isRequired
+                    value={grade}
+                    onChange={event => setGrade(event.target.value)}
+                    placeholder="3"
+                    errorMessage={fieldErrors.grade}
+                  />
 
-              <PrimaryButton
-                type="submit"
-                variant="primary"
-                size="L"
-                width="100%"
-                label={isSubmitting ? '가입 중...' : '가입하기'}
-                disabled={!isSignUpEnabled}
-              />
-            </SignUpFormSection>
-          </>
-        ) : null}
+                  <TextField
+                    id="classNumber"
+                    name="classNumber"
+                    inputMode="numeric"
+                    label="반"
+                    isRequired
+                    value={classNumber}
+                    onChange={event => setClassNumber(event.target.value)}
+                    placeholder="2"
+                    errorMessage={fieldErrors.classNumber}
+                  />
+                </InlineTwoColumn>
+              </SignUpBodySection>
+            ) : step === 'CLASS_CODE_READY' ? (
+              <SignUpBodySection>
+                <ClassCodeCard>
+                  <ClassLabel>
+                    {schoolName || '한국초등학교'} {grade || '3'}학년 {classNumber || '2'}반
+                  </ClassLabel>
+                  <ClassCode>{generatedClassCode}</ClassCode>
+                </ClassCodeCard>
 
-        {step === 'SIGN_UP_SUCCESS' ? (
-          <SuccessSection>
-            <SuccessIconContainer>
-              <IcCheck />
-            </SuccessIconContainer>
-            <SuccessTitle>가입 완료</SuccessTitle>
-            <SuccessDescription>
-              교사 가입이 완료되었어요.
-              <br />
-              이제 학급을 개설하고, 학부모님과 안전한 소통을 시작해보세요.
-            </SuccessDescription>
-
-            {globalError ? (
-              <ErrorBox role="alert">
-                <ErrorIcon>
-                  <IcInfo />
-                </ErrorIcon>
-                <ErrorMessageGroup>
-                  <ErrorTitle>{globalError.title}</ErrorTitle>
-                  <ErrorDescription>{globalError.description}</ErrorDescription>
-                </ErrorMessageGroup>
-              </ErrorBox>
+                <InlineButton
+                  type="button"
+                  variant="ghost"
+                  size="L"
+                  icon={IcCopy}
+                  label="학급코드 복사하기"
+                  onClick={handleCopyClassCode}
+                />
+              </SignUpBodySection>
             ) : null}
 
-            <PrimaryButton
-              type="button"
-              variant="primary"
-              size="L"
-              width="100%"
-              label={isCreatingClassCode ? '학급 코드 생성 중...' : '학급 개설하기'}
-              onClick={handleOpenClassCodeModal}
-              disabled={isCreatingClassCode}
-            />
-          </SuccessSection>
-        ) : null}
+            <SignUpActionSection>
+              {globalError ? (
+                <Alert title={globalError.title} description={globalError.description} />
+              ) : null}
 
-        {step === 'CLASS_CODE_READY' ? (
-          <SuccessSection>
-            <SuccessIconContainer>
-              <IcSparkles />
-            </SuccessIconContainer>
-            <SuccessTitle>학급 코드 생성 완료</SuccessTitle>
-            <SuccessDescription>
-              학급이 개설되었어요.
-              <br />
-              생성된 학급 코드를 학부모님들께 공유해주세요.
-            </SuccessDescription>
-
-            <ClassCodeCard>
-              <ClassLabel>
-                {schoolName || '한국초등학교'} {grade || '3'}학년 {classNumber || '2'}반
-              </ClassLabel>
-              <ClassCode>{generatedClassCode}</ClassCode>
-            </ClassCodeCard>
-
-            <CopyButton
-              type="button"
-              variant="ghost"
-              size="L"
-              width="100%"
-              icon={IcCopy}
-              label="학급코드 복사하기"
-              onClick={handleCopyClassCode}
-            />
-
-            <PrimaryButton
-              type="button"
-              variant="primary"
-              size="L"
-              width="100%"
-              label="수신함으로 이동"
-              onClick={handleGoToInbox}
-            />
-          </SuccessSection>
-        ) : null}
-      </Card>
+              <InlineButton
+                type={step === 'FORM' ? 'submit' : 'button'}
+                variant="primary"
+                size="L"
+                label={actionLabel}
+                disabled={isSignUpActionDisabled}
+                onClick={step === 'FORM' ? undefined : handleSignUpAction}
+              />
+            </SignUpActionSection>
+          </SignUpFormSection>
+        </SignUpCard>
+      </SignUpContent>
 
       <FooterText>© 2026, 소프티 All rights reserved.</FooterText>
-    </PageContainer>
+    </SignUpPageContainer>
   );
 };
 
-const PageContainer = styled.div`
+const SignUpPageContainer = styled.div`
   min-height: 100vh;
-  background: ${({ theme }) => theme.colors.background.bg5};
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 24px 16px 28px;
+  padding: 24px 16px;
+  gap: 60px;
 `;
 
-const Card = styled.section`
-  width: 100%;
-  max-width: 560px;
-  border-radius: 20px;
-  background: ${({ theme }) => theme.colors.background.bg3};
-  box-shadow: ${({ theme }) => theme.colors.shadow.modal};
-  padding: 28px 30px;
+const SignUpContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
 
-  @media (max-width: 640px) {
-    padding: 20px 16px;
-    border-radius: 16px;
-  }
+const SignUpCard = styled.section`
+  display: flex;
+  flex-direction: column;
+  max-width: 441px;
+  background: ${({ theme }) => theme.colors.background.bg1};
+  box-shadow: ${({ theme }) => theme.colors.shadow.modal};
+  border-radius: 16px;
+  padding: 20px 40px 40px;
+  gap: 40px;
 `;
 
 const ProgressTrack = styled.div`
@@ -260,153 +228,82 @@ const ProgressFill = styled.div`
   transition: width 0.2s ease;
 `;
 
-const Title = styled.h1`
-  ${({ theme }) => theme.fonts.title2};
-  margin: 34px 0 0;
-  color: ${({ theme }) => theme.colors.text.text1};
-  text-align: center;
+const SignUpHeaderSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 24px;
 `;
 
-const Description = styled.p`
-  ${({ theme }) => theme.fonts.body3};
-  margin: 12px 0 0;
-  color: ${({ theme }) => theme.colors.text.text3};
-  text-align: center;
-`;
-
-const SignUpFormSection = styled.form`
-  margin-top: 28px;
+const SignUpHeaderTextArea = styled.div`
   display: flex;
   flex-direction: column;
   gap: 16px;
 `;
 
-const InlineTwoColumn = styled.div`
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 10px;
-`;
-
-const ErrorBox = styled.div`
-  display: flex;
-  gap: 10px;
-  align-items: center;
-  border-radius: 16px;
-  border: 1px solid ${({ theme }) => theme.colors.semantic.error};
-  background: ${({ theme }) => theme.colors.semantic.errorSoft};
-  padding: 12px 14px;
-`;
-
-const ErrorIcon = styled.span`
-  display: inline-flex;
-  color: ${({ theme }) => theme.colors.semantic.error};
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
-`;
-
-const ErrorMessageGroup = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-`;
-
-const ErrorTitle = styled.p`
-  ${({ theme }) => theme.fonts.labelXS};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
-`;
-
-const ErrorDescription = styled.p`
-  ${({ theme }) => theme.fonts.caption};
-  margin: 0;
-  color: ${({ theme }) => theme.colors.semantic.error};
-`;
-
-const PrimaryButton = styled(InlineButton)`
-  margin-top: 14px;
-  width: 100%;
-  height: 52px;
-  border-radius: 12px;
-`;
-
-const SuccessSection = styled.section`
-  margin-top: 20px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
-
-const SuccessIconContainer = styled.span`
-  width: 64px;
-  height: 64px;
-  border-radius: 999px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  background: ${({ theme }) => theme.colors.background.bg4};
-  color: ${({ theme }) => theme.colors.brand.dark};
-
-  svg {
-    width: 30px;
-    height: 30px;
-  }
-`;
-
-const SuccessTitle = styled.h2`
+const Title = styled.h1`
+  text-align: center;
   ${({ theme }) => theme.fonts.title2};
-  margin: 22px 0 0;
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
-const SuccessDescription = styled.p`
-  ${({ theme }) => theme.fonts.body3};
-  margin: 12px 0 0;
-  color: ${({ theme }) => theme.colors.text.text2};
+const Description = styled.p`
   text-align: center;
-  line-height: 1.7;
+  white-space: pre-line;
+  ${({ theme }) => theme.fonts.body3};
+  color: ${({ theme }) => theme.colors.text.text3};
+`;
+
+const SignUpFormSection = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 40px;
+`;
+
+const SignUpBodySection = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 361px);
+  gap: 16px;
+`;
+
+const InlineTwoColumn = styled.div`
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 8px;
 `;
 
 const ClassCodeCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   width: 100%;
-  margin-top: 18px;
   border-radius: 14px;
   border: 1px solid ${({ theme }) => theme.colors.border.border1};
   background: ${({ theme }) => theme.colors.background.bg4};
   padding: 18px 14px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
   gap: 10px;
 `;
 
 const ClassLabel = styled.p`
   ${({ theme }) => theme.fonts.caption};
-  margin: 0;
   color: ${({ theme }) => theme.colors.brand.dark};
 `;
 
 const ClassCode = styled.p`
   ${({ theme }) => theme.fonts.title2};
-  margin: 0;
   letter-spacing: 0.02em;
   color: ${({ theme }) => theme.colors.text.text1};
 `;
 
-const CopyButton = styled(InlineButton)`
-  margin-top: 16px;
-  width: 100%;
-
-  svg {
-    width: 18px;
-    height: 18px;
-  }
+const SignUpActionSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: min(100%, 361px);
+  gap: 12px;
 `;
 
 const FooterText = styled.p`
   ${({ theme }) => theme.fonts.body3};
   color: ${({ theme }) => theme.colors.neutral.neutral500};
-  margin: 18px 0 0;
 `;

--- a/src/features/auth/components/TeacherSignUpForm.tsx
+++ b/src/features/auth/components/TeacherSignUpForm.tsx
@@ -3,13 +3,13 @@ import { useTheme } from '@emotion/react';
 import type { ComponentProps } from 'react';
 import { InlineButton } from '@/components/common/InlineButton';
 import { TextField } from '@/components/common/TextField';
-import { IconButton } from '@/components/common/IconButton';
 import { Alert } from '@/components/common/Alert';
 import { IconBadge } from '@/components/common/IconBadge';
 import type { AuthErrorMessage } from '@/features/auth/lib/getAuthErrorMessage';
 import type { SignUpStep } from '@/features/auth/hooks/useTeacherSignUpForm';
-import { IcCopy, IcLogout } from '@/icons';
+import { IcCopy } from '@/icons';
 import { TEACHER_SIGN_UP_STEP_CONTENT } from '@/features/auth/constants/signupSteps';
+import { useCopyClassCode } from '@/hooks/useCopyClassCode';
 
 type TeacherSignUpFormProps = {
   teacherName: string;
@@ -30,10 +30,8 @@ type TeacherSignUpFormProps = {
   setSchoolName: (value: string) => void;
   setGrade: (value: string) => void;
   setClassNumber: (value: string) => void;
-  handleLogout: () => void;
   handleSubmit: NonNullable<ComponentProps<'form'>['onSubmit']>;
   handleSignUpAction: () => void | Promise<void>;
-  handleCopyClassCode: () => void | Promise<void>;
 };
 
 export const TeacherSignUpForm = ({
@@ -50,12 +48,11 @@ export const TeacherSignUpForm = ({
   setSchoolName,
   setGrade,
   setClassNumber,
-  handleLogout,
   handleSubmit,
   handleSignUpAction,
-  handleCopyClassCode,
 }: TeacherSignUpFormProps) => {
   const theme = useTheme();
+  const { copyClassCode } = useCopyClassCode();
   const {
     progressRatio,
     iconBadge: Icon,
@@ -65,143 +62,113 @@ export const TeacherSignUpForm = ({
   } = TEACHER_SIGN_UP_STEP_CONTENT[step];
 
   return (
-    <SignUpPageContainer>
-      <SignUpContent>
-        {step === 'FORM' && (
-          <IconButton
-            icon={IcLogout}
-            variant="plain"
-            onClick={handleLogout}
-            accessibilityLabel="로그아웃"
-          />
-        )}
-        <SignUpCard>
-          <ProgressTrack aria-hidden>
-            <ProgressFill style={{ width: `${progressRatio * 100}%` }} />
-          </ProgressTrack>
+    <SignUpCard>
+      <ProgressTrack aria-hidden>
+        <ProgressFill style={{ width: `${progressRatio * 100}%` }} />
+      </ProgressTrack>
 
-          <SignUpFormSection onSubmit={handleSubmit}>
-            <SignUpHeaderSection>
-              {Icon && (
-                <IconBadge
-                  icon={Icon}
-                  bgColor={theme.colors.background.bg4}
-                  color={theme.colors.brand.dark}
-                />
-              )}
-              <SignUpHeaderTextArea>
-                <Title>{title}</Title>
-                <Description>{description}</Description>
-              </SignUpHeaderTextArea>
-            </SignUpHeaderSection>
-            {step === 'FORM' ? (
-              <SignUpBodySection>
-                <TextField
-                  id="teacherName"
-                  name="teacherName"
-                  label="이름"
-                  isRequired
-                  value={teacherName}
-                  onChange={event => setTeacherName(event.target.value)}
-                  placeholder="홍길동"
-                  errorMessage={fieldErrors.teacherName}
-                />
+      <SignUpFormSection onSubmit={handleSubmit}>
+        <SignUpHeaderSection>
+          {Icon && (
+            <IconBadge
+              icon={Icon}
+              bgColor={theme.colors.background.bg4}
+              color={theme.colors.brand.dark}
+            />
+          )}
+          <SignUpHeaderTextArea>
+            <Title>{title}</Title>
+            <Description>{description}</Description>
+          </SignUpHeaderTextArea>
+        </SignUpHeaderSection>
+        {step === 'FORM' ? (
+          <SignUpBodySection>
+            <TextField
+              id="teacherName"
+              name="teacherName"
+              label="이름"
+              isRequired
+              value={teacherName}
+              onChange={event => setTeacherName(event.target.value)}
+              placeholder="홍길동"
+              errorMessage={fieldErrors.teacherName}
+            />
 
-                <TextField
-                  id="schoolName"
-                  name="schoolName"
-                  label="학교명"
-                  isRequired
-                  value={schoolName}
-                  onChange={event => setSchoolName(event.target.value)}
-                  placeholder="한국초등학교"
-                  errorMessage={fieldErrors.schoolName}
-                />
+            <TextField
+              id="schoolName"
+              name="schoolName"
+              label="학교명"
+              isRequired
+              value={schoolName}
+              onChange={event => setSchoolName(event.target.value)}
+              placeholder="한국초등학교"
+              errorMessage={fieldErrors.schoolName}
+            />
 
-                <InlineTwoColumn>
-                  <TextField
-                    id="grade"
-                    name="grade"
-                    inputMode="numeric"
-                    label="학년"
-                    isRequired
-                    value={grade}
-                    onChange={event => setGrade(event.target.value)}
-                    placeholder="3"
-                    errorMessage={fieldErrors.grade}
-                  />
-
-                  <TextField
-                    id="classNumber"
-                    name="classNumber"
-                    inputMode="numeric"
-                    label="반"
-                    isRequired
-                    value={classNumber}
-                    onChange={event => setClassNumber(event.target.value)}
-                    placeholder="2"
-                    errorMessage={fieldErrors.classNumber}
-                  />
-                </InlineTwoColumn>
-              </SignUpBodySection>
-            ) : step === 'CLASS_CODE_READY' ? (
-              <SignUpBodySection>
-                <ClassCodeCard>
-                  <ClassLabel>
-                    {schoolName || '한국초등학교'} {grade || '3'}학년 {classNumber || '2'}반
-                  </ClassLabel>
-                  <ClassCode>{generatedClassCode}</ClassCode>
-                </ClassCodeCard>
-
-                <InlineButton
-                  type="button"
-                  variant="ghost"
-                  size="L"
-                  icon={IcCopy}
-                  label="학급코드 복사하기"
-                  onClick={handleCopyClassCode}
-                />
-              </SignUpBodySection>
-            ) : null}
-
-            <SignUpActionSection>
-              {globalError ? (
-                <Alert title={globalError.title} description={globalError.description} />
-              ) : null}
-
-              <InlineButton
-                type={step === 'FORM' ? 'submit' : 'button'}
-                variant="primary"
-                size="L"
-                label={actionLabel}
-                disabled={isSignUpActionDisabled}
-                onClick={step === 'FORM' ? undefined : handleSignUpAction}
+            <InlineTwoColumn>
+              <TextField
+                id="grade"
+                name="grade"
+                inputMode="numeric"
+                label="학년"
+                isRequired
+                value={grade}
+                onChange={event => setGrade(event.target.value)}
+                placeholder="3"
+                errorMessage={fieldErrors.grade}
               />
-            </SignUpActionSection>
-          </SignUpFormSection>
-        </SignUpCard>
-      </SignUpContent>
 
-      <FooterText>© 2026, 소프티 All rights reserved.</FooterText>
-    </SignUpPageContainer>
+              <TextField
+                id="classNumber"
+                name="classNumber"
+                inputMode="numeric"
+                label="반"
+                isRequired
+                value={classNumber}
+                onChange={event => setClassNumber(event.target.value)}
+                placeholder="2"
+                errorMessage={fieldErrors.classNumber}
+              />
+            </InlineTwoColumn>
+          </SignUpBodySection>
+        ) : step === 'CLASS_CODE_READY' ? (
+          <SignUpBodySection>
+            <ClassCodeCard>
+              <ClassLabel>
+                {schoolName || '한국초등학교'} {grade || '3'}학년 {classNumber || '2'}반
+              </ClassLabel>
+              <ClassCode>{generatedClassCode}</ClassCode>
+            </ClassCodeCard>
+
+            <InlineButton
+              type="button"
+              variant="ghost"
+              size="L"
+              icon={IcCopy}
+              label="학급코드 복사하기"
+              onClick={() => void copyClassCode(generatedClassCode)}
+            />
+          </SignUpBodySection>
+        ) : null}
+
+        <SignUpActionSection>
+          {globalError ? (
+            <Alert title={globalError.title} description={globalError.description} />
+          ) : null}
+
+          <InlineButton
+            type={step === 'FORM' ? 'submit' : 'button'}
+            variant="primary"
+            size="L"
+            label={actionLabel}
+            disabled={isSignUpActionDisabled}
+            onClick={step === 'FORM' ? undefined : handleSignUpAction}
+          />
+        </SignUpActionSection>
+      </SignUpFormSection>
+    </SignUpCard>
   );
 };
-
-const SignUpPageContainer = styled.div`
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 24px 16px;
-  gap: 60px;
-`;
-
-const SignUpContent = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-`;
 
 const SignUpCard = styled.section`
   display: flex;
@@ -301,9 +268,4 @@ const SignUpActionSection = styled.div`
   flex-direction: column;
   width: min(100%, 361px);
   gap: 12px;
-`;
-
-const FooterText = styled.p`
-  ${({ theme }) => theme.fonts.body3};
-  color: ${({ theme }) => theme.colors.neutral.neutral500};
 `;

--- a/src/features/auth/constants/signupSteps.ts
+++ b/src/features/auth/constants/signupSteps.ts
@@ -1,0 +1,38 @@
+import type { SignUpStep } from '@/features/auth/hooks/useTeacherSignUpForm';
+import type { IconComponent } from '@/types/icon';
+import { IcCheck, IcSparkles } from '@/icons';
+
+export const TEACHER_SIGN_UP_STEP_CONTENT = {
+  FORM: {
+    progressRatio: 0.33,
+    iconBadge: null,
+    title: '교사 정보 입력',
+    description: '가입을 위해 선생님의 정보를 입력해주세요.',
+    actionLabel: '가입하기',
+  },
+  SIGN_UP_SUCCESS: {
+    progressRatio: 0.66,
+    iconBadge: IcCheck,
+    title: '가입 완료',
+    description: `교사 가입이 완료되었어요.
+이제 학급을 개설하고, 학부모님과 안전한 소통을 시작해보세요.`,
+    actionLabel: '학급 개설하기',
+  },
+  CLASS_CODE_READY: {
+    progressRatio: 1,
+    iconBadge: IcSparkles,
+    title: '학급 코드 생성 완료',
+    description: `학급이 개설되었어요.
+생성된 학급 코드를 학부모님들께 공유해주세요.`,
+    actionLabel: '수신함으로 이동',
+  },
+} satisfies Record<
+  SignUpStep,
+  {
+    progressRatio: number;
+    iconBadge: IconComponent | null;
+    title: string;
+    description: string;
+    actionLabel: string;
+  }
+>;

--- a/src/features/auth/hooks/useTeacherSignUpForm.ts
+++ b/src/features/auth/hooks/useTeacherSignUpForm.ts
@@ -26,7 +26,6 @@ import {
 } from '@/utils/teacherClassInfoValidation';
 import { authApi, authSession, teacherAuthApi } from '@/services/auth';
 import { ROUTES } from '@/constants/routes';
-import { useToast } from '@/hooks/useToast';
 
 type FieldErrors = {
   teacherName?: string;
@@ -83,7 +82,6 @@ export const useTeacherSignUpForm = () => {
   const navigate = useNavigate();
   const { authStatus, setSignedIn, setSignedOut } = useAuth();
   const { logout } = useLogout();
-  const { showToast } = useToast();
 
   const storedTeacherSignUpState = getStoredTeacherSignUpState();
 
@@ -365,27 +363,6 @@ export const useTeacherSignUpForm = () => {
     void handleSignUpAction();
   };
 
-  const handleCopyClassCode = async () => {
-    const classCode = generatedClassCode.trim();
-
-    if (!classCode) {
-      showToast('복사할 학급코드가 없어요.', 'error');
-      return;
-    }
-
-    if (!navigator.clipboard) {
-      showToast('현재 브라우저에서는 복사를 지원하지 않아요.', 'error');
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(classCode);
-      showToast('학급코드를 복사했어요.', 'success');
-    } catch {
-      showToast('학급코드 복사에 실패했어요.', 'error');
-    }
-  };
-
   return {
     teacherName,
     schoolName,
@@ -403,6 +380,5 @@ export const useTeacherSignUpForm = () => {
     handleLogout,
     handleSubmit,
     handleSignUpAction,
-    handleCopyClassCode,
   };
 };

--- a/src/features/auth/hooks/useTeacherSignUpForm.ts
+++ b/src/features/auth/hooks/useTeacherSignUpForm.ts
@@ -13,6 +13,7 @@ import {
   getNumberDigits,
   getSchoolNameErrorMessage,
   getTeacherNameErrorMessage,
+  validateGradeText,
   validateNumberText,
   validateSchoolName,
   validateTeacherName,
@@ -32,7 +33,11 @@ export type SignUpStep = 'FORM' | 'SIGN_UP_SUCCESS' | 'CLASS_CODE_READY';
 
 type GlobalError = AuthErrorMessage | null;
 
-const FORM_ERROR_FALLBACK: AuthErrorMessage = {
+type ApiErrorResponse = {
+  message?: string;
+};
+
+const SIGN_UP_ERROR_FALLBACK: AuthErrorMessage = {
   title: '회원가입 중 문제가 발생했어요.',
   description: '잠시 후 다시 시도해 주세요.',
 };
@@ -42,7 +47,29 @@ const CLASS_CODE_ERROR_FALLBACK: AuthErrorMessage = {
   description: '잠시 후 다시 시도해 주세요.',
 };
 
+const ALREADY_SIGNED_UP_ERROR: AuthErrorMessage = {
+  title: '이미 교사 회원가입이 완료된 사용자입니다.',
+  description: '로그아웃한 뒤 다시 로그인해 주세요.',
+};
+
 const parseNumberText = (value: string) => Number(value.trim());
+
+const getApiErrorMessage = (error: AxiosError) => {
+  const responseData = error.response?.data as ApiErrorResponse | undefined;
+
+  return responseData?.message;
+};
+
+const getTeacherSignUpErrorMessage = (message?: string): AuthErrorMessage => {
+  if (message === ALREADY_SIGNED_UP_ERROR.title) {
+    return ALREADY_SIGNED_UP_ERROR;
+  }
+
+  return {
+    title: message || SIGN_UP_ERROR_FALLBACK.title,
+    description: SIGN_UP_ERROR_FALLBACK.description,
+  };
+};
 
 type FormSubmitHandler = NonNullable<ComponentProps<'form'>['onSubmit']>;
 
@@ -77,7 +104,7 @@ export const useTeacherSignUpForm = () => {
     const isValid =
       validateTeacherName(teacherName) &&
       validateSchoolName(schoolName) &&
-      validateNumberText(grade) &&
+      validateGradeText(grade) &&
       validateNumberText(classNumber);
 
     return {
@@ -186,10 +213,7 @@ export const useTeacherSignUpForm = () => {
       });
 
       if (!response.success) {
-        setGlobalError({
-          title: response.message || FORM_ERROR_FALLBACK.title,
-          description: FORM_ERROR_FALLBACK.description,
-        });
+        setGlobalError(getTeacherSignUpErrorMessage(response.message));
         return;
       }
 
@@ -202,9 +226,14 @@ export const useTeacherSignUpForm = () => {
           resetInvalidAuthSession();
           return;
         }
+
+        if (status === 409) {
+          setGlobalError(getTeacherSignUpErrorMessage(getApiErrorMessage(error)));
+          return;
+        }
       }
 
-      setGlobalError(getAuthErrorMessage(error, FORM_ERROR_FALLBACK));
+      setGlobalError(getAuthErrorMessage(error, SIGN_UP_ERROR_FALLBACK));
     } finally {
       setIsSubmitting(false);
     }

--- a/src/features/auth/hooks/useTeacherSignUpForm.ts
+++ b/src/features/auth/hooks/useTeacherSignUpForm.ts
@@ -8,6 +8,12 @@ import {
   type AuthErrorMessage,
 } from '@/features/auth/lib/getAuthErrorMessage';
 import {
+  clearStoredTeacherSignUpState,
+  getStoredTeacherSignUpState,
+  setStoredTeacherSignUpState,
+  type StoredTeacherSignUpState,
+} from '@/features/auth/lib/teacherSignUpSessionStorage';
+import {
   getClassNumberErrorMessage,
   getGradeErrorMessage,
   getNumberDigits,
@@ -79,15 +85,19 @@ export const useTeacherSignUpForm = () => {
   const { logout } = useLogout();
   const { showToast } = useToast();
 
-  const [teacherName, setTeacherName] = useState('');
-  const [schoolName, setSchoolName] = useState('');
-  const [grade, setGrade] = useState('');
-  const [classNumber, setClassNumber] = useState('');
+  const storedTeacherSignUpState = getStoredTeacherSignUpState();
+
+  const [teacherName, setTeacherName] = useState(storedTeacherSignUpState?.teacherName ?? '');
+  const [schoolName, setSchoolName] = useState(storedTeacherSignUpState?.schoolName ?? '');
+  const [grade, setGrade] = useState(storedTeacherSignUpState?.grade ?? '');
+  const [classNumber, setClassNumber] = useState(storedTeacherSignUpState?.classNumber ?? '');
   const [globalError, setGlobalError] = useState<GlobalError>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isCreatingClassCode, setIsCreatingClassCode] = useState(false);
-  const [step, setStep] = useState<SignUpStep>('FORM');
-  const [generatedClassCode, setGeneratedClassCode] = useState('');
+  const [step, setStep] = useState<SignUpStep>(storedTeacherSignUpState?.step ?? 'FORM');
+  const [generatedClassCode, setGeneratedClassCode] = useState(
+    storedTeacherSignUpState?.generatedClassCode ?? ''
+  );
 
   const validationResult = useMemo(() => {
     const fieldErrors: FieldErrors = {
@@ -133,20 +143,62 @@ export const useTeacherSignUpForm = () => {
     return false;
   }, [isCreatingClassCode, isSignUpEnabled, step]);
 
+  const getCurrentStoredTeacherSignUpState = (
+    overrides?: Partial<StoredTeacherSignUpState>
+  ): StoredTeacherSignUpState => {
+    return {
+      step,
+      teacherName,
+      schoolName,
+      grade,
+      classNumber,
+      generatedClassCode,
+      ...overrides,
+    };
+  };
+
+  const saveTeacherSignUpState = (overrides?: Partial<StoredTeacherSignUpState>) => {
+    setStoredTeacherSignUpState(getCurrentStoredTeacherSignUpState(overrides));
+  };
+
   const handleChangeTeacherName = (value: string) => {
     setTeacherName(value);
+
+    saveTeacherSignUpState({
+      step: 'FORM',
+      teacherName: value,
+    });
   };
 
   const handleChangeSchoolName = (value: string) => {
     setSchoolName(value);
+
+    saveTeacherSignUpState({
+      step: 'FORM',
+      schoolName: value,
+    });
   };
 
   const handleChangeGrade = (value: string) => {
-    setGrade(getNumberDigits(value));
+    const nextGrade = getNumberDigits(value);
+
+    setGrade(nextGrade);
+
+    saveTeacherSignUpState({
+      step: 'FORM',
+      grade: nextGrade,
+    });
   };
 
   const handleChangeClassNumber = (value: string) => {
-    setClassNumber(getNumberDigits(value));
+    const nextClassNumber = getNumberDigits(value);
+
+    setClassNumber(nextClassNumber);
+
+    saveTeacherSignUpState({
+      step: 'FORM',
+      classNumber: nextClassNumber,
+    });
   };
 
   const handleLogout = () => {
@@ -154,6 +206,7 @@ export const useTeacherSignUpForm = () => {
       return;
     }
 
+    clearStoredTeacherSignUpState();
     logout();
   };
 
@@ -182,6 +235,7 @@ export const useTeacherSignUpForm = () => {
   };
 
   const resetInvalidAuthSession = () => {
+    clearStoredTeacherSignUpState();
     authSession.clearSession();
     setSignedOut();
     navigate(ROUTES.root, { replace: true });
@@ -218,6 +272,9 @@ export const useTeacherSignUpForm = () => {
       }
 
       setStep('SIGN_UP_SUCCESS');
+      saveTeacherSignUpState({
+        step: 'SIGN_UP_SUCCESS',
+      });
     } catch (error) {
       if (error instanceof AxiosError) {
         const status = error.response?.status;
@@ -255,8 +312,14 @@ export const useTeacherSignUpForm = () => {
         return;
       }
 
-      setGeneratedClassCode(classCodeResponse.data.classCode.trim());
+      const nextClassCode = classCodeResponse.data.classCode.trim();
+
+      setGeneratedClassCode(nextClassCode);
       setStep('CLASS_CODE_READY');
+      saveTeacherSignUpState({
+        step: 'CLASS_CODE_READY',
+        generatedClassCode: nextClassCode,
+      });
     } catch (error) {
       if (error instanceof AxiosError) {
         const status = error.response?.status;
@@ -275,6 +338,7 @@ export const useTeacherSignUpForm = () => {
 
   const goToInbox = async () => {
     await applySignedInState();
+    clearStoredTeacherSignUpState();
     navigate(ROUTES.teacherThreadList, { replace: true });
   };
 

--- a/src/features/auth/hooks/useTeacherSignUpForm.ts
+++ b/src/features/auth/hooks/useTeacherSignUpForm.ts
@@ -2,6 +2,7 @@ import { AxiosError } from 'axios';
 import { useMemo, useState, type ComponentProps } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/hooks/useAuth';
+import { useLogout } from '@/hooks/useLogout';
 import {
   getAuthErrorMessage,
   type AuthErrorMessage,
@@ -36,6 +37,11 @@ const FORM_ERROR_FALLBACK: AuthErrorMessage = {
   description: '잠시 후 다시 시도해 주세요.',
 };
 
+const CLASS_CODE_ERROR_FALLBACK: AuthErrorMessage = {
+  title: '학급코드 생성에 실패했어요.',
+  description: '잠시 후 다시 시도해 주세요.',
+};
+
 const parseNumberText = (value: string) => Number(value.trim());
 
 type FormSubmitHandler = NonNullable<ComponentProps<'form'>['onSubmit']>;
@@ -43,6 +49,7 @@ type FormSubmitHandler = NonNullable<ComponentProps<'form'>['onSubmit']>;
 export const useTeacherSignUpForm = () => {
   const navigate = useNavigate();
   const { authStatus, setSignedIn, setSignedOut } = useAuth();
+  const { logout } = useLogout();
   const { showToast } = useToast();
 
   const [teacherName, setTeacherName] = useState('');
@@ -87,6 +94,18 @@ export const useTeacherSignUpForm = () => {
     authStatus === 'SIGNUP_REQUIRED' &&
     step === 'FORM';
 
+  const isSignUpActionDisabled = useMemo(() => {
+    if (step === 'FORM') {
+      return !isSignUpEnabled;
+    }
+
+    if (step === 'SIGN_UP_SUCCESS') {
+      return isCreatingClassCode;
+    }
+
+    return false;
+  }, [isCreatingClassCode, isSignUpEnabled, step]);
+
   const handleChangeTeacherName = (value: string) => {
     setTeacherName(value);
   };
@@ -101,6 +120,14 @@ export const useTeacherSignUpForm = () => {
 
   const handleChangeClassNumber = (value: string) => {
     setClassNumber(getNumberDigits(value));
+  };
+
+  const handleLogout = () => {
+    if (step !== 'FORM') {
+      return;
+    }
+
+    logout();
   };
 
   const applySignedInState = async () => {
@@ -127,9 +154,13 @@ export const useTeacherSignUpForm = () => {
     }
   };
 
-  const handleSubmit: FormSubmitHandler = async event => {
-    event.preventDefault();
+  const resetInvalidAuthSession = () => {
+    authSession.clearSession();
+    setSignedOut();
+    navigate(ROUTES.root, { replace: true });
+  };
 
+  const submitTeacherSignUp = async () => {
     setGlobalError(null);
 
     if (authStatus !== 'SIGNUP_REQUIRED') {
@@ -168,22 +199,18 @@ export const useTeacherSignUpForm = () => {
         const status = error.response?.status;
 
         if (status === 401 || status === 403) {
-          authSession.clearSession();
-          setSignedOut();
-          navigate(ROUTES.root, { replace: true });
+          resetInvalidAuthSession();
           return;
         }
       }
 
-      const nextErrorState = getAuthErrorMessage(error, FORM_ERROR_FALLBACK);
-
-      setGlobalError(nextErrorState);
+      setGlobalError(getAuthErrorMessage(error, FORM_ERROR_FALLBACK));
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const handleOpenClassCodeModal = async () => {
+  const createClassCode = async () => {
     setGlobalError(null);
 
     try {
@@ -193,8 +220,8 @@ export const useTeacherSignUpForm = () => {
 
       if (!classCodeResponse.success || !classCodeResponse.data?.classCode?.trim()) {
         setGlobalError({
-          title: classCodeResponse.message || '학급코드 생성에 실패했어요.',
-          description: '잠시 후 다시 시도해 주세요.',
+          title: classCodeResponse.message || CLASS_CODE_ERROR_FALLBACK.title,
+          description: CLASS_CODE_ERROR_FALLBACK.description,
         });
         return;
       }
@@ -206,22 +233,43 @@ export const useTeacherSignUpForm = () => {
         const status = error.response?.status;
 
         if (status === 401 || status === 403) {
-          authSession.clearSession();
-          setSignedOut();
-          navigate(ROUTES.root, { replace: true });
+          resetInvalidAuthSession();
           return;
         }
       }
 
-      const nextErrorState = getAuthErrorMessage(error, {
-        title: '학급코드 생성에 실패했어요.',
-        description: '잠시 후 다시 시도해 주세요.',
-      });
-
-      setGlobalError(nextErrorState);
+      setGlobalError(getAuthErrorMessage(error, CLASS_CODE_ERROR_FALLBACK));
     } finally {
       setIsCreatingClassCode(false);
     }
+  };
+
+  const goToInbox = async () => {
+    await applySignedInState();
+    navigate(ROUTES.teacherThreadList, { replace: true });
+  };
+
+  const handleSignUpAction = async () => {
+    if (isSignUpActionDisabled) {
+      return;
+    }
+
+    if (step === 'FORM') {
+      await submitTeacherSignUp();
+      return;
+    }
+
+    if (step === 'SIGN_UP_SUCCESS') {
+      await createClassCode();
+      return;
+    }
+
+    await goToInbox();
+  };
+
+  const handleSubmit: FormSubmitHandler = event => {
+    event.preventDefault();
+    void handleSignUpAction();
   };
 
   const handleCopyClassCode = async () => {
@@ -245,11 +293,6 @@ export const useTeacherSignUpForm = () => {
     }
   };
 
-  const handleGoToInbox = async () => {
-    await applySignedInState();
-    navigate(ROUTES.teacherThreadList, { replace: true });
-  };
-
   return {
     teacherName,
     schoolName,
@@ -257,18 +300,16 @@ export const useTeacherSignUpForm = () => {
     classNumber,
     fieldErrors: validationResult.errors,
     globalError,
-    isSubmitting,
-    isCreatingClassCode,
-    isSignUpEnabled,
     step,
     generatedClassCode,
+    isSignUpActionDisabled,
     setTeacherName: handleChangeTeacherName,
     setSchoolName: handleChangeSchoolName,
     setGrade: handleChangeGrade,
     setClassNumber: handleChangeClassNumber,
+    handleLogout,
     handleSubmit,
-    handleOpenClassCodeModal,
+    handleSignUpAction,
     handleCopyClassCode,
-    handleGoToInbox,
   };
 };

--- a/src/features/auth/lib/teacherSignUpSessionStorage.ts
+++ b/src/features/auth/lib/teacherSignUpSessionStorage.ts
@@ -1,0 +1,51 @@
+import type { SignUpStep } from '@/features/auth/hooks/useTeacherSignUpForm';
+
+export type StoredTeacherSignUpState = {
+  step: SignUpStep;
+  teacherName: string;
+  schoolName: string;
+  grade: string;
+  classNumber: string;
+  generatedClassCode: string;
+};
+
+const TEACHER_SIGN_UP_STORAGE_KEY = 'softy-teacher-sign-up-state';
+
+const isSignUpStep = (value: unknown): value is SignUpStep => {
+  return value === 'FORM' || value === 'SIGN_UP_SUCCESS' || value === 'CLASS_CODE_READY';
+};
+
+export const getStoredTeacherSignUpState = (): StoredTeacherSignUpState | null => {
+  const storedValue = sessionStorage.getItem(TEACHER_SIGN_UP_STORAGE_KEY);
+
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue = JSON.parse(storedValue) as Partial<StoredTeacherSignUpState>;
+
+    if (!isSignUpStep(parsedValue.step)) {
+      return null;
+    }
+
+    return {
+      step: parsedValue.step,
+      teacherName: parsedValue.teacherName ?? '',
+      schoolName: parsedValue.schoolName ?? '',
+      grade: parsedValue.grade ?? '',
+      classNumber: parsedValue.classNumber ?? '',
+      generatedClassCode: parsedValue.generatedClassCode ?? '',
+    };
+  } catch {
+    return null;
+  }
+};
+
+export const setStoredTeacherSignUpState = (state: StoredTeacherSignUpState) => {
+  sessionStorage.setItem(TEACHER_SIGN_UP_STORAGE_KEY, JSON.stringify(state));
+};
+
+export const clearStoredTeacherSignUpState = () => {
+  sessionStorage.removeItem(TEACHER_SIGN_UP_STORAGE_KEY);
+};

--- a/src/hooks/useCopyClassCode.ts
+++ b/src/hooks/useCopyClassCode.ts
@@ -1,0 +1,40 @@
+import { useToast } from '@/hooks/useToast';
+import { copyTextToClipboard, type CopyTextToClipboardResult } from '@/utils/copyTextToClipboard';
+
+const CLASS_CODE_COPY_TOAST_MESSAGE = {
+  SUCCESS: {
+    message: '학급코드를 복사했어요.',
+    type: 'success',
+  },
+  EMPTY_TEXT: {
+    message: '복사할 학급코드가 없어요.',
+    type: 'error',
+  },
+  UNSUPPORTED: {
+    message: '현재 브라우저에서는 복사를 지원하지 않아요.',
+    type: 'error',
+  },
+  FAILED: {
+    message: '학급코드 복사에 실패했어요.',
+    type: 'error',
+  },
+} satisfies Record<
+  CopyTextToClipboardResult,
+  {
+    message: string;
+    type: 'success' | 'error';
+  }
+>;
+
+export const useCopyClassCode = () => {
+  const { showToast } = useToast();
+
+  const copyClassCode = async (classCode: string | null | undefined) => {
+    const result = await copyTextToClipboard(classCode);
+    const toastMessage = CLASS_CODE_COPY_TOAST_MESSAGE[result];
+
+    showToast(toastMessage.message, toastMessage.type);
+  };
+
+  return { copyClassCode };
+};

--- a/src/pages/auth/TeacherSignUpPage.tsx
+++ b/src/pages/auth/TeacherSignUpPage.tsx
@@ -1,7 +1,49 @@
-import { TeacherSignUpForm } from '@/features/auth/components/TeacherSignUpForm';
+import styled from '@emotion/styled';
 import { useTeacherSignUpForm } from '@/features/auth/hooks/useTeacherSignUpForm';
+import { TeacherSignUpForm } from '@/features/auth/components/TeacherSignUpForm';
+import { IconButton } from '@/components/common/IconButton';
+import { IcLogout } from '@/icons';
 
 export const TeacherSignUpPage = () => {
-  const formState = useTeacherSignUpForm();
-  return <TeacherSignUpForm {...formState} />;
+  const { step, handleLogout, ...teacherSignUpFormProps } = useTeacherSignUpForm();
+
+  return (
+    <TeacherSignUpPageContainer>
+      <TeacherSignUpContent>
+        {step === 'FORM' ? (
+          <IconButton
+            icon={IcLogout}
+            variant="plain"
+            onClick={handleLogout}
+            accessibilityLabel="로그아웃"
+          />
+        ) : null}
+
+        <TeacherSignUpForm step={step} {...teacherSignUpFormProps} />
+      </TeacherSignUpContent>
+
+      <FooterText>© 2026, 소프티 All rights reserved.</FooterText>
+    </TeacherSignUpPageContainer>
+  );
 };
+
+const TeacherSignUpPageContainer = styled.div`
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 24px 16px;
+  gap: 60px;
+`;
+
+const TeacherSignUpContent = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const FooterText = styled.p`
+  ${({ theme }) => theme.fonts.body3};
+  color: ${({ theme }) => theme.colors.neutral.neutral500};
+`;

--- a/src/pages/auth/TeacherSignUpPage.tsx
+++ b/src/pages/auth/TeacherSignUpPage.tsx
@@ -10,7 +10,7 @@ export const TeacherSignUpPage = () => {
   return (
     <TeacherSignUpPageContainer>
       <TeacherSignUpContent>
-        {step === 'FORM' ? (
+        {step !== 'SIGN_UP_SUCCESS' ? (
           <IconButton
             icon={IcLogout}
             variant="plain"
@@ -40,6 +40,7 @@ const TeacherSignUpPageContainer = styled.div`
 const TeacherSignUpContent = styled.div`
   display: flex;
   flex-direction: column;
+  width: min(100%, 441px);
   gap: 16px;
 `;
 

--- a/src/pages/teacher/settings/TeacherSettingsPage.tsx
+++ b/src/pages/teacher/settings/TeacherSettingsPage.tsx
@@ -1,14 +1,10 @@
 import styled from '@emotion/styled';
-import { useCallback, useEffect, useMemo, useState } from 'react';
 import { AxiosError } from 'axios';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
-import { InlineButton } from '@/components/common/InlineButton';
-import { TextField } from '@/components/common/TextField';
-import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
-import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
-import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
 import { useToast } from '@/hooks/useToast';
 import { useTeacherWithdraw } from '@/features/teacher/settings/hooks/useTeacherWithdraw';
+import { useCopyClassCode } from '@/hooks/useCopyClassCode';
 import {
   getClassNumberErrorMessage,
   getGradeErrorMessage,
@@ -17,6 +13,11 @@ import {
   validateNumberText,
   validateSchoolName,
 } from '@/utils/teacherClassInfoValidation';
+import { InlineButton } from '@/components/common/InlineButton';
+import { TextField } from '@/components/common/TextField';
+import type { AppLayoutOutletContext } from '@/layouts/AppLayout';
+import { teacherApi, type TeacherSetting } from '@/services/teacher/teacherApi';
+import { IcChange, IcCheck, IcCopy, IcError, IcInfo } from '@/icons';
 
 type WorkdayKey = 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat' | 'sun';
 
@@ -116,6 +117,7 @@ export const TeacherSettingsPage = () => {
     handleConfirmWithdraw,
     handleLogout,
   } = useTeacherWithdraw();
+  const { copyClassCode } = useCopyClassCode();
 
   const { setHeaderActions } = useOutletContext<AppLayoutOutletContext>();
 
@@ -332,35 +334,6 @@ export const TeacherSettingsPage = () => {
     } finally {
       setIsClassChangeSubmitting(false);
     }
-  };
-
-  const copyClassCodeWithToast = async (rawClassCode: string | null | undefined) => {
-    const classCode = rawClassCode?.trim();
-
-    if (!classCode) {
-      showToast('복사할 학급코드가 없어요.', 'error');
-      return;
-    }
-
-    if (!navigator.clipboard) {
-      showToast('현재 브라우저에서는 복사를 지원하지 않아요.', 'error');
-      return;
-    }
-
-    try {
-      await navigator.clipboard.writeText(classCode);
-      showToast('학급코드를 복사했어요.', 'success');
-    } catch {
-      showToast('학급코드 복사에 실패했어요.', 'error');
-    }
-  };
-
-  const handleCopyClassCode = async () => {
-    await copyClassCodeWithToast(setting?.classCode);
-  };
-
-  const handleCopyNewClassCode = async () => {
-    await copyClassCodeWithToast(newClassCode);
   };
 
   const handleToggleWorkday = (targetKey: WorkdayKey) => {
@@ -622,7 +595,7 @@ export const TeacherSettingsPage = () => {
               <ClassCodeBadge>
                 {setting?.classCode?.trim() ? setting.classCode : '-'}
               </ClassCodeBadge>
-              <CodeCopyButton type="button" onClick={handleCopyClassCode}>
+              <CodeCopyButton type="button" onClick={() => void copyClassCode(setting?.classCode)}>
                 <IcCopy />
                 학급코드 복사하기
               </CodeCopyButton>
@@ -786,7 +759,7 @@ export const TeacherSettingsPage = () => {
               <SuccessCodeValue>{newClassCode || '-'}</SuccessCodeValue>
             </SuccessCodeCard>
 
-            <SuccessCopyButton type="button" onClick={handleCopyNewClassCode}>
+            <SuccessCopyButton type="button" onClick={() => void copyClassCode(newClassCode)}>
               <IcCopy />
               학급코드 복사하기
             </SuccessCopyButton>

--- a/src/utils/copyTextToClipboard.ts
+++ b/src/utils/copyTextToClipboard.ts
@@ -1,0 +1,22 @@
+export type CopyTextToClipboardResult = 'SUCCESS' | 'EMPTY_TEXT' | 'UNSUPPORTED' | 'FAILED';
+
+export const copyTextToClipboard = async (
+  text: string | null | undefined
+): Promise<CopyTextToClipboardResult> => {
+  const trimmedText = text?.trim();
+
+  if (!trimmedText) {
+    return 'EMPTY_TEXT';
+  }
+
+  if (!navigator.clipboard) {
+    return 'UNSUPPORTED';
+  }
+
+  try {
+    await navigator.clipboard.writeText(trimmedText);
+    return 'SUCCESS';
+  } catch {
+    return 'FAILED';
+  }
+};

--- a/src/utils/teacherClassInfoValidation.ts
+++ b/src/utils/teacherClassInfoValidation.ts
@@ -4,6 +4,8 @@ const schoolNameInvalidCharPattern = /[^A-Z0-9ㄱ-ㅎㅏ-ㅣ가-힣\s·.'’()-]
 
 const MIN_NAME_LENGTH = 2;
 const MIN_SCHOOL_NAME_LENGTH = 2;
+const MIN_GRADE = 1;
+const MAX_GRADE = 6;
 
 export const getTextWithoutSpaces = (value: string) => {
   return value.replace(/\s/g, '');
@@ -95,6 +97,16 @@ export const validateNumberText = (value: string) => {
   return /^\d+$/.test(value.trim());
 };
 
+export const validateGradeText = (value: string) => {
+  if (!validateNumberText(value)) {
+    return false;
+  }
+
+  const grade = Number(value);
+
+  return grade >= MIN_GRADE && grade <= MAX_GRADE;
+};
+
 export const getGradeErrorMessage = (value: string) => {
   if (value.length === 0) {
     return undefined;
@@ -102,6 +114,10 @@ export const getGradeErrorMessage = (value: string) => {
 
   if (!validateNumberText(value)) {
     return '숫자만 입력해 주세요.';
+  }
+
+  if (!validateGradeText(value)) {
+    return '학년은 1~6 사이여야 해요.';
   }
 
   return undefined;


### PR DESCRIPTION
<!-- PR 제목은 "[TYPE] 작업 내용 #이슈 번호" 형식으로 작성해 주세요 ! -->

## #️⃣ Issue Number

<!--- ex) #이슈번호, #이슈번호 -->
#60 

## 📝 요약(Summary)

<!--- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- 교사 회원가입 화면의 단계별 문구, 진행률, 액션 처리 구조 정리
- 회원가입 카드 및 입력 영역 레이아웃 정리
- 가입 완료 단계를 제외하고 로그아웃 버튼이 노출되도록 수정
- 회원가입 진행 상태를 sessionStorage에 저장해 새로고침 후에도 입력값과 진행 단계가 유지되도록 개선
- 학급코드 복사 로직을 공통 유틸과 훅으로 분리해 회원가입/설정 화면에서 재사용하도록 개선

## 🛠️ PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## ✅ 변경사항

- 교사 회원가입 단계별 문구와 진행률 상수화
- 회원가입 단계별 액션을 useTeacherSignUpForm에서 분기하도록 정리
- 가입 완료 단계를 제외하고 로그아웃 버튼이 노출되도록 분기 조건 수정
- 로그아웃 버튼 및 FooterText를 회원가입 페이지 레벨로 분리
- 회원가입 카드가 단계별 콘텐츠 크기에 따라 줄어들지 않도록 width 처리
- 회원가입 카드 내부 입력 영역과 액션 영역이 전체 너비를 사용하도록 수정
- 학급 코드 생성 완료 단계의 텍스트 스타일과 카드 표시 스타일 조정
- TextField가 부모 너비 안에서 안정적으로 렌더링되도록 width 처리
- 학년/반 입력 영역이 2열 레이아웃에서 넘치지 않도록 수정
- 학년 입력값을 1~6 범위로 검증하도록 수정
- 이미 교사 회원가입이 완료된 사용자 오류에 재로그인 안내 문구 추가
- 회원가입 409 응답에서도 서버 메시지 기반 에러 문구를 매핑하도록 처리
- 교사 회원가입 진행 상태를 sessionStorage에 저장하도록 추가
- 입력 단계에서 새로고침해도 입력값이 유지되도록 처리
- 가입 완료 및 학급 코드 생성 완료 단계가 새로고침 후에도 유지되도록 처리
- 로그아웃, 인증 만료, 수신함 이동 시 저장된 회원가입 진행 상태 제거
- 클립보드 복사 결과를 반환하는 copyTextToClipboard 유틸 추가
- 학급코드 복사 및 토스트 처리 useCopyClassCode 훅으로 분리
- 교사 회원가입 및 설정 화면에서 학급코드 복사 훅을 직접 사용하도록 수정

## 📷 Screenshots or Video

<!---- 변경된 이미지나 비디오를 첨부해 주세요. 없으면 왜 없는지 설명(ex. 코드 리팩토링) !-->
<img width="1551" height="868" alt="image" src="https://github.com/user-attachments/assets/b01722b0-e695-4a3d-a165-bf0fb2163e1b" />

<img width="1546" height="862" alt="image" src="https://github.com/user-attachments/assets/2676c5c7-a008-4e89-a588-0c2b481659c3" />

<img width="1552" height="863" alt="image" src="https://github.com/user-attachments/assets/4d692c16-85dd-4cbc-a77e-46268c3753fe" />
