### PR TITLE
[FIX] 의도태그 일치 및 상태 라벨 수정 #66

### DIFF
--- a/src/components/teacher/reports/ReportRoomListSection.tsx
+++ b/src/components/teacher/reports/ReportRoomListSection.tsx
@@ -72,7 +72,7 @@ export const ReportRoomListSection = ({
     <ReportListSection>
       <ReportList>
         {reportItems.map(item => {
-          const intentType = getInquiryIntentByType(item.intentType);
+          const intentType = getInquiryIntentByType(item.intentLabel);
           const parentDisplayName = formatUserDisplayNameWithSuffix({
             name: item.parentName,
             suffix: '학부모님',
@@ -98,7 +98,9 @@ export const ReportRoomListSection = ({
                 </LastMessageDate>
               </ReportItemTopRow>
 
-              <IntentBadge $intentType={intentType}>{INQUIRY_INTENT_LABEL[intentType]}</IntentBadge>
+              <IntentBadge $intentType={intentType}>
+                {item.intentLabel || INQUIRY_INTENT_LABEL[intentType]}
+              </IntentBadge>
             </ReportListItem>
           );
         })}

--- a/src/components/teacher/threadDetail/ChatHeader.tsx
+++ b/src/components/teacher/threadDetail/ChatHeader.tsx
@@ -14,6 +14,7 @@ import { formatUserDisplayNameWithSuffix } from '@/utils/formatUserDisplayName';
 type ChatHeaderProps = {
   counterpartName: string;
   studentName: string;
+  intentLabel?: string;
   intentType: InquiryIntentType;
   status: ThreadStatus;
   isStatusMenuOpen: boolean;
@@ -25,6 +26,7 @@ type ChatHeaderProps = {
 export const ChatHeader = ({
   counterpartName,
   studentName,
+  intentLabel,
   intentType,
   status,
   isStatusMenuOpen,
@@ -50,7 +52,9 @@ export const ChatHeader = ({
         <ChatHeaderMetaArea>
           <StudentName>{studentDisplayName}</StudentName>
 
-          <IntentTag $intentType={intentType}>{INQUIRY_INTENT_LABEL[intentType]}</IntentTag>
+          <IntentTag $intentType={intentType}>
+            {intentLabel && intentLabel.trim() ? intentLabel : INQUIRY_INTENT_LABEL[intentType]}
+          </IntentTag>
 
           <StatusDropdownArea>
             <StatusTagButton

--- a/src/constants/inquiryIntent.ts
+++ b/src/constants/inquiryIntent.ts
@@ -26,15 +26,37 @@ export const INQUIRY_INTENT_COLOR_KEY: Record<InquiryIntentType, keyof ColorsTyp
   ETC: 'etc',
 };
 
+const INTENT_LABEL_TO_TYPE: Record<string, InquiryIntentType> = {
+  출석: INQUIRY_INTENT.ATTENDANCE,
+  출결: INQUIRY_INTENT.ATTENDANCE,
+  상담: INQUIRY_INTENT.COUNSELING,
+  요청: INQUIRY_INTENT.REQUEST,
+  문의: INQUIRY_INTENT.INQUIRY,
+  기타: INQUIRY_INTENT.ETC,
+};
+
 export const getInquiryIntentByType = (intentType?: string | null): InquiryIntentType => {
+  const normalized = intentType?.trim();
+
+  if (!normalized) {
+    return INQUIRY_INTENT.ETC;
+  }
+
+  const upper = normalized.toUpperCase();
+
   if (
-    intentType === INQUIRY_INTENT.ATTENDANCE ||
-    intentType === INQUIRY_INTENT.COUNSELING ||
-    intentType === INQUIRY_INTENT.REQUEST ||
-    intentType === INQUIRY_INTENT.INQUIRY ||
-    intentType === INQUIRY_INTENT.ETC
+    upper === INQUIRY_INTENT.ATTENDANCE ||
+    upper === INQUIRY_INTENT.COUNSELING ||
+    upper === INQUIRY_INTENT.REQUEST ||
+    upper === INQUIRY_INTENT.INQUIRY ||
+    upper === INQUIRY_INTENT.ETC
   ) {
-    return intentType;
+    return upper as InquiryIntentType;
+  }
+
+  const fromLabel = INTENT_LABEL_TO_TYPE[normalized];
+  if (fromLabel) {
+    return fromLabel;
   }
 
   return INQUIRY_INTENT.ETC;

--- a/src/constants/inquiryStatus.ts
+++ b/src/constants/inquiryStatus.ts
@@ -1,4 +1,4 @@
-import type { ColorsType } from '@/styles/colors';
+﻿import type { ColorsType } from '@/styles/colors';
 
 export const INQUIRY_STATUS = {
   IN_PROGRESS: 'IN_PROGRESS',
@@ -9,7 +9,7 @@ export type InquiryStatusType = (typeof INQUIRY_STATUS)[keyof typeof INQUIRY_STA
 
 export const INQUIRY_STATUS_LABEL: Record<InquiryStatusType, string> = {
   IN_PROGRESS: '처리중',
-  COMPLETED: '완료',
+  COMPLETED: '처리완료',
 };
 
 export const INQUIRY_STATUS_COLOR_KEY: Record<InquiryStatusType, keyof ColorsType['threadStatus']> =

--- a/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
+++ b/src/features/teacher/threadDetail/hooks/useThreadDetail.ts
@@ -146,7 +146,8 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
 
   const counterpartName = chatRoomDetail?.counterpartName ?? '';
   const studentName = chatRoomDetail?.studentName ?? '';
-  const intentType: InquiryIntentType = getInquiryIntentByType(chatRoomDetail?.intentType);
+  const intentLabel = chatRoomDetail?.intentLabel ?? '';
+  const intentType: InquiryIntentType = getInquiryIntentByType(intentLabel);
 
   const loadState: DetailLoadState = !isValidChatRoomId
     ? 'error'
@@ -196,6 +197,7 @@ export const useThreadDetail = ({ chatRoomId }: UseTeacherThreadDetailParams) =>
     detailErrorMessage,
     counterpartName,
     studentName,
+    intentLabel,
     intentType,
     messages,
     messagesError,

--- a/src/features/teacher/threadDetail/types.ts
+++ b/src/features/teacher/threadDetail/types.ts
@@ -9,6 +9,7 @@ export type ChatRoomDetailData = {
   counterpartName: string;
   studentName: string;
   intentType?: string | null;
+  intentLabel?: string | null;
   status: ThreadStatus;
 };
 

--- a/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
+++ b/src/pages/teacher/threadDetail/TeacherThreadDetailPage.tsx
@@ -40,6 +40,7 @@ export const TeacherThreadDetailPage = () => {
     detailErrorMessage,
     counterpartName,
     studentName,
+    intentLabel,
     intentType,
     messages,
     messagesError,
@@ -73,6 +74,7 @@ export const TeacherThreadDetailPage = () => {
       <ChatHeader
         counterpartName={counterpartName}
         studentName={studentName}
+        intentLabel={intentLabel}
         intentType={intentType}
         status={status}
         isStatusMenuOpen={isStatusMenuOpen}

--- a/src/services/teacher/reportsApi.ts
+++ b/src/services/teacher/reportsApi.ts
@@ -29,6 +29,7 @@ export type ReportChatRoomItem = {
   parentName: string;
   studentName: string;
   intentType: string;
+  intentLabel: string;
   status: string;
   lastMessageAt: string;
 };


### PR DESCRIPTION

#️⃣ Issue Number
#66

📝 요약(Summary)
수신함/채팅방 상세/증빙 리포트에서 의도태그 표시가 불일치하거나 기타로 고정되는 문제를 수정했습니다.
추가로 상태 드롭다운 라벨을 완료 → 처리완료로 변경해 화면 문구 정합성을 맞췄습니다.

🛠️ PR 유형
어떤 변경 사항이 있나요?

새로운 기능 추가

- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

✅ 변경사항
1.
채팅방 상세 의도태그를 API intentLabel 기준으로 매핑/표시하도록 수정
증빙 리포트 의도태그를 API intentLabel 기준으로 매핑/표시하도록 수정
채팅방 상세 타입 정의에 intentLabel 필드 반영
2.
드롭다운 상태 라벨 텍스트 변경
IN_PROGRESS: 처리중
COMPLETED: 처리완료
📷 Screenshots or Video
<img width="1438" height="1218" alt="스크린샷 2026-05-31 175135" src="https://github.com/user-attachments/assets/0b5ca657-daca-49f5-be16-e5e1f830a47c" />
<img width="1034" height="336" alt="스크린샷 2026-05-31 175148" src="https://github.com/user-attachments/assets/8164aac9-ec42-4c6f-9ea1-03ffe6cf1066" />
<img width="2410" height="1001" alt="스크린샷 2026-05-31 175200" src="https://github.com/user-attachments/assets/033cd1f3-a084-423d-916f-b01b37544c64" />
<img width="1901" height="510" alt="스크린샷 2026-05-31 175207" src="https://github.com/user-attachments/assets/12e2b00b-b0b2-42fa-be2c-11641cbb0dc2" />
<img width="1547" height="1161" alt="스크린샷 2026-05-31 175219" src="https://github.com/user-attachments/assets/1f2be9bd-3135-4937-918c-fdea63039a09" />
